### PR TITLE
Add LotusLisans WooCommerce reseller integration plugin

### DIFF
--- a/lotuslisans-reseller/assets/css/admin.css
+++ b/lotuslisans-reseller/assets/css/admin.css
@@ -1,0 +1,17 @@
+.lotuslisans-reseller .lotuslisans-test-result {
+    margin-left: 10px;
+    font-weight: 600;
+}
+
+.lotuslisans-reseller .lotuslisans-test-result.success {
+    color: #1d9d5f;
+}
+
+.lotuslisans-reseller .lotuslisans-test-result.error {
+    color: #d63638;
+}
+
+.lotuslisans-reseller .lotuslisans-sync-summary {
+    list-style: disc;
+    margin-left: 20px;
+}

--- a/lotuslisans-reseller/assets/js/admin.js
+++ b/lotuslisans-reseller/assets/js/admin.js
@@ -1,0 +1,42 @@
+(function($){
+    'use strict';
+
+    $(function(){
+        var $button = $('#lotuslisans-test-connection');
+        if ( !$button.length ) {
+            return;
+        }
+
+        var $result = $('.lotuslisans-test-result');
+
+        $button.on('click', function(event){
+            event.preventDefault();
+
+            if ( typeof lotuslisansReseller === 'undefined' ) {
+                return;
+            }
+
+            $button.prop('disabled', true);
+            $result.removeClass('error success').text(lotuslisansReseller.testing);
+
+            $.post(
+                lotuslisansReseller.ajaxUrl,
+                {
+                    action: 'lotuslisans_test_connection',
+                    nonce: lotuslisansReseller.nonce
+                }
+            ).done(function(response){
+                if ( response && response.success ) {
+                    $result.addClass('success').text(response.data);
+                } else {
+                    var message = response && response.data ? response.data : lotuslisansReseller.error;
+                    $result.addClass('error').text(message);
+                }
+            }).fail(function(){
+                $result.addClass('error').text(lotuslisansReseller.error);
+            }).always(function(){
+                $button.prop('disabled', false);
+            });
+        });
+    });
+})(jQuery);

--- a/lotuslisans-reseller/includes/class-lotuslisans-admin.php
+++ b/lotuslisans-reseller/includes/class-lotuslisans-admin.php
@@ -1,0 +1,452 @@
+<?php
+/**
+ * Admin functionality.
+ *
+ * @package LotusLisansReseller
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class LotusLisans_Admin {
+
+    /**
+     * Plugin instance.
+     *
+     * @var LotusLisans_Reseller_Plugin
+     */
+    protected $plugin;
+
+    /**
+     * API client.
+     *
+     * @var LotusLisans_API_Client
+     */
+    protected $api_client;
+
+    /**
+     * Constructor.
+     *
+     * @param LotusLisans_Reseller_Plugin $plugin    Plugin instance.
+     * @param LotusLisans_API_Client      $api_client API client.
+     */
+    public function __construct( LotusLisans_Reseller_Plugin $plugin, LotusLisans_API_Client $api_client ) {
+        $this->plugin     = $plugin;
+        $this->api_client = $api_client;
+
+        add_action( 'admin_menu', array( $this, 'register_menu' ) );
+        add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+        add_action( 'wp_ajax_lotuslisans_test_connection', array( $this, 'ajax_test_connection' ) );
+        add_action( 'admin_post_lotuslisans_import_products', array( $this, 'handle_import_products' ) );
+    }
+
+    /**
+     * Register plugin admin menu.
+     */
+    public function register_menu() {
+        add_menu_page(
+            __( 'LotusLisans API', 'lotuslisans-reseller' ),
+            __( 'Reseller - API', 'lotuslisans-reseller' ),
+            'manage_options',
+            'lotuslisans-reseller',
+            array( $this, 'render_settings_page' ),
+            'dashicons-rest-api',
+            58
+        );
+    }
+
+    /**
+     * Enqueue admin assets.
+     *
+     * @param string $hook Current page hook.
+     */
+    public function enqueue_assets( $hook ) {
+        if ( 'toplevel_page_lotuslisans-reseller' !== $hook ) {
+            return;
+        }
+
+        wp_enqueue_style(
+            'lotuslisans-reseller-admin',
+            LOTUSLISANS_RESELLER_URL . 'assets/css/admin.css',
+            array(),
+            LOTUSLISANS_RESELLER_VERSION
+        );
+
+        wp_enqueue_script(
+            'lotuslisans-reseller-admin',
+            LOTUSLISANS_RESELLER_URL . 'assets/js/admin.js',
+            array( 'jquery' ),
+            LOTUSLISANS_RESELLER_VERSION,
+            true
+        );
+
+        wp_localize_script(
+            'lotuslisans-reseller-admin',
+            'lotuslisansReseller',
+            array(
+                'ajaxUrl'  => admin_url( 'admin-ajax.php' ),
+                'nonce'    => wp_create_nonce( 'lotuslisans_test_connection' ),
+                'testing'  => __( 'Bağlantı test ediliyor...', 'lotuslisans-reseller' ),
+                'error'    => __( 'Beklenmeyen bir hata oluştu.', 'lotuslisans-reseller' ),
+                'success'  => __( 'Bağlantı başarılı.', 'lotuslisans-reseller' ),
+            )
+        );
+    }
+
+    /**
+     * Render settings page.
+     */
+    public function render_settings_page() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+
+        $options  = $this->plugin->get_options();
+        $api_key  = isset( $options['api_key'] ) ? $options['api_key'] : '';
+        $balance  = $this->plugin->get_cached_balance();
+        $snapshot = $this->plugin->get_product_snapshot();
+        ?>
+        <div class="wrap lotuslisans-reseller">
+            <h1><?php esc_html_e( 'LotusLisans API Ayarları', 'lotuslisans-reseller' ); ?></h1>
+            <form method="post" action="options.php">
+                <?php
+                settings_fields( 'lotuslisans_reseller_settings' );
+                ?>
+                <table class="form-table" role="presentation">
+                    <tbody>
+                        <tr>
+                            <th scope="row">
+                                <label for="lotuslisans-reseller-api-key"><?php esc_html_e( 'API Anahtarı', 'lotuslisans-reseller' ); ?></label>
+                            </th>
+                            <td>
+                                <input type="text" class="regular-text" id="lotuslisans-reseller-api-key" name="<?php echo esc_attr( LotusLisans_Reseller_Plugin::OPTION_KEY ); ?>[api_key]" value="<?php echo esc_attr( $api_key ); ?>" autocomplete="off" />
+                                <p class="description"><?php esc_html_e( 'LotusLisans panelinizden aldığınız API anahtarını giriniz.', 'lotuslisans-reseller' ); ?></p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <?php submit_button( __( 'Kaydet', 'lotuslisans-reseller' ) ); ?>
+            </form>
+
+            <hr />
+
+            <h2><?php esc_html_e( 'Bağlantı Yönetimi', 'lotuslisans-reseller' ); ?></h2>
+            <p>
+                <button type="button" class="button button-secondary" id="lotuslisans-test-connection">
+                    <?php esc_html_e( 'Bağlantıyı Test Et', 'lotuslisans-reseller' ); ?>
+                </button>
+                <span class="lotuslisans-test-result" aria-live="polite"></span>
+            </p>
+
+            <?php if ( $balance && isset( $balance['credit'] ) ) : ?>
+                <div class="notice notice-success inline">
+                    <p>
+                        <?php
+                        printf(
+                            /* translators: %s: balance amount */
+                            esc_html__( 'Güncel LotusLisans bakiyeniz: %s', 'lotuslisans-reseller' ),
+                            esc_html( $balance['credit'] )
+                        );
+                        ?>
+                    </p>
+                </div>
+            <?php endif; ?>
+
+            <hr />
+
+            <h2><?php esc_html_e( 'Ürün Yönetimi', 'lotuslisans-reseller' ); ?></h2>
+            <?php if ( ! class_exists( 'WooCommerce' ) ) : ?>
+                <div class="notice notice-error inline"><p><?php esc_html_e( 'WooCommerce eklentisi etkin değil. Lütfen WooCommerce kurulumu olmadan ürün içe aktarımı yapmayınız.', 'lotuslisans-reseller' ); ?></p></div>
+            <?php endif; ?>
+            <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+                <?php wp_nonce_field( 'lotuslisans_import_products' ); ?>
+                <input type="hidden" name="action" value="lotuslisans_import_products" />
+                <?php submit_button( __( 'Tüm Ürünleri WooCommerce Taslaklarına Aktar', 'lotuslisans-reseller' ), 'primary', 'lotuslisans-import-products' ); ?>
+            </form>
+
+            <?php if ( ! empty( $snapshot ) ) : ?>
+                <h3><?php esc_html_e( 'Son Senkronizasyon Özeti', 'lotuslisans-reseller' ); ?></h3>
+                <p><?php esc_html_e( 'Aşağıda son alınan ürün verilerinden bazı bilgiler yer alıyor.', 'lotuslisans-reseller' ); ?></p>
+                <ul class="lotuslisans-sync-summary">
+                    <li><?php printf( esc_html__( 'Ürün sayısı: %d', 'lotuslisans-reseller' ), count( $snapshot ) ); ?></li>
+                </ul>
+            <?php endif; ?>
+        </div>
+        <?php
+    }
+
+    /**
+     * AJAX callback for testing the API connection.
+     */
+    public function ajax_test_connection() {
+        check_ajax_referer( 'lotuslisans_test_connection', 'nonce' );
+
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( __( 'Yetkiniz bulunmuyor.', 'lotuslisans-reseller' ) );
+        }
+
+        $response = $this->api_client->get_user();
+
+        if ( is_wp_error( $response ) ) {
+            wp_send_json_error( $response->get_error_message() );
+        }
+
+        $message = __( 'Bağlantı başarılı.', 'lotuslisans-reseller' );
+
+        if ( isset( $response['data']['credit'] ) ) {
+            $message = sprintf(
+                /* translators: %s: credit balance */
+                __( 'Bağlantı başarılı. Güncel bakiyeniz: %s', 'lotuslisans-reseller' ),
+                esc_html( $response['data']['credit'] )
+            );
+        }
+
+        wp_send_json_success( $message );
+    }
+
+    /**
+     * Handle product import submission.
+     */
+    public function handle_import_products() {
+        if ( ! current_user_can( 'manage_woocommerce' ) && ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Bu işlem için izniniz yok.', 'lotuslisans-reseller' ) );
+        }
+
+        check_admin_referer( 'lotuslisans_import_products' );
+
+        $products_response = $this->api_client->get_products();
+
+        if ( is_wp_error( $products_response ) ) {
+            $this->plugin->buffer_notice( $products_response->get_error_message(), 'error' );
+            wp_safe_redirect( wp_get_referer() ? wp_get_referer() : admin_url( 'admin.php?page=lotuslisans-reseller' ) );
+            exit;
+        }
+
+        $products = isset( $products_response['data'] ) && is_array( $products_response['data'] ) ? $products_response['data'] : array();
+
+        $result = $this->import_products( $products );
+
+        $this->handle_product_change_notifications( $products );
+
+        if ( $result['created'] > 0 || $result['updated'] > 0 ) {
+            $this->plugin->buffer_notice(
+                sprintf(
+                    /* translators: 1: created count 2: updated count */
+                    esc_html__( '%1$d yeni ürün taslak olarak oluşturuldu, %2$d ürün güncellendi.', 'lotuslisans-reseller' ),
+                    $result['created'],
+                    $result['updated']
+                ),
+                'success'
+            );
+        } else {
+            $this->plugin->buffer_notice( esc_html__( 'İçe aktarılacak yeni ürün bulunamadı.', 'lotuslisans-reseller' ), 'info' );
+        }
+
+        wp_safe_redirect( wp_get_referer() ? wp_get_referer() : admin_url( 'admin.php?page=lotuslisans-reseller' ) );
+        exit;
+    }
+
+    /**
+     * Import products into WooCommerce.
+     *
+     * @param array $products API product list.
+     *
+     * @return array
+     */
+    protected function import_products( array $products ) {
+        $results = array(
+            'created' => 0,
+            'updated' => 0,
+        );
+
+        if ( empty( $products ) ) {
+            return $results;
+        }
+
+        if ( ! class_exists( 'WooCommerce' ) ) {
+            $this->plugin->buffer_notice( esc_html__( 'WooCommerce bulunamadı. Ürünler içe aktarılamadı.', 'lotuslisans-reseller' ), 'error' );
+            return $results;
+        }
+
+        foreach ( $products as $product ) {
+            if ( empty( $product['id'] ) ) {
+                continue;
+            }
+
+            $existing_id = $this->find_product_by_remote_id( $product['id'] );
+
+            if ( $existing_id ) {
+                $updated = $this->update_existing_product( $existing_id, $product );
+                if ( $updated ) {
+                    $results['updated']++;
+                }
+                continue;
+            }
+
+            $created = $this->create_product( $product );
+            if ( $created ) {
+                $results['created']++;
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * Find a local product by remote ID.
+     *
+     * @param int $remote_id Remote product ID.
+     *
+     * @return int|false
+     */
+    protected function find_product_by_remote_id( $remote_id ) {
+        $query = new WP_Query(
+            array(
+                'post_type'      => 'product',
+                'posts_per_page' => 1,
+                'post_status'    => 'any',
+                'fields'         => 'ids',
+                'meta_key'       => '_lotuslisans_product_id',
+                'meta_value'     => $remote_id,
+            )
+        );
+
+        if ( empty( $query->posts ) ) {
+            return false;
+        }
+
+        return (int) $query->posts[0];
+    }
+
+    /**
+     * Create WooCommerce product draft.
+     *
+     * @param array $product Product data.
+     *
+     * @return bool
+     */
+    protected function create_product( array $product ) {
+        $post_id = wp_insert_post(
+            array(
+                'post_title'   => isset( $product['title'] ) ? sanitize_text_field( $product['title'] ) : __( 'LotusLisans Ürünü', 'lotuslisans-reseller' ),
+                'post_content' => isset( $product['content'] ) ? wp_kses_post( $product['content'] ) : '',
+                'post_status'  => 'draft',
+                'post_type'    => 'product',
+            ),
+            true
+        );
+
+        if ( is_wp_error( $post_id ) ) {
+            $this->plugin->buffer_notice( $post_id->get_error_message(), 'error' );
+            return false;
+        }
+
+        $this->update_product_meta( $post_id, $product );
+
+        return true;
+    }
+
+    /**
+     * Update an existing product.
+     *
+     * @param int   $post_id Product ID.
+     * @param array $product Product data.
+     *
+     * @return bool
+     */
+    protected function update_existing_product( $post_id, array $product ) {
+        $updated_post = array(
+            'ID'           => $post_id,
+            'post_title'   => isset( $product['title'] ) ? sanitize_text_field( $product['title'] ) : get_the_title( $post_id ),
+            'post_content' => isset( $product['content'] ) ? wp_kses_post( $product['content'] ) : get_post_field( 'post_content', $post_id ),
+        );
+
+        $result = wp_update_post( $updated_post, true );
+
+        if ( is_wp_error( $result ) ) {
+            $this->plugin->buffer_notice( $result->get_error_message(), 'error' );
+            return false;
+        }
+
+        $this->update_product_meta( $post_id, $product );
+
+        return true;
+    }
+
+    /**
+     * Update WooCommerce product meta information.
+     *
+     * @param int   $post_id Product ID.
+     * @param array $product Product data.
+     */
+    protected function update_product_meta( $post_id, array $product ) {
+        if ( isset( $product['amount'] ) ) {
+            $price = function_exists( 'wc_format_decimal' ) ? wc_format_decimal( $product['amount'] ) : sanitize_text_field( $product['amount'] );
+            update_post_meta( $post_id, '_regular_price', $price );
+            update_post_meta( $post_id, '_price', $price );
+        }
+
+        $available = isset( $product['available'] ) ? (bool) $product['available'] : false;
+        update_post_meta( $post_id, '_stock_status', $available ? 'instock' : 'onbackorder' );
+        update_post_meta( $post_id, '_manage_stock', 'no' );
+        update_post_meta( $post_id, '_lotuslisans_product_id', (int) $product['id'] );
+        update_post_meta( $post_id, '_lotuslisans_available', $available ? 'yes' : 'no' );
+        update_post_meta( $post_id, '_virtual', 'yes' );
+        update_post_meta( $post_id, '_downloadable', 'no' );
+    }
+
+    /**
+     * Handle notifications for product changes.
+     *
+     * @param array $products Latest product payload.
+     */
+    protected function handle_product_change_notifications( array $products ) {
+        $previous = $this->plugin->get_product_snapshot();
+        $changes  = array();
+
+        $indexed_previous = array();
+        foreach ( $previous as $product ) {
+            if ( isset( $product['id'] ) ) {
+                $indexed_previous[ $product['id'] ] = $product;
+            }
+        }
+
+        foreach ( $products as $product ) {
+            if ( ! isset( $product['id'] ) ) {
+                continue;
+            }
+
+            $id = (int) $product['id'];
+
+            if ( ! isset( $indexed_previous[ $id ] ) ) {
+                $changes[] = sprintf(
+                    /* translators: %s: product title */
+                    esc_html__( 'Yeni ürün bulundu: %s', 'lotuslisans-reseller' ),
+                    isset( $product['title'] ) ? esc_html( $product['title'] ) : $id
+                );
+                continue;
+            }
+
+            $previous_product = $indexed_previous[ $id ];
+
+            if ( isset( $previous_product['amount'], $product['amount'] ) && $previous_product['amount'] !== $product['amount'] ) {
+                $changes[] = sprintf(
+                    /* translators: 1: product title 2: old price 3: new price */
+                    esc_html__( '%1$s fiyatı güncellendi: %2$s → %3$s', 'lotuslisans-reseller' ),
+                    isset( $product['title'] ) ? esc_html( $product['title'] ) : $id,
+                    esc_html( $previous_product['amount'] ),
+                    esc_html( $product['amount'] )
+                );
+            }
+        }
+
+        if ( ! empty( $changes ) ) {
+            foreach ( $changes as $change ) {
+                $this->plugin->buffer_notice( $change, 'warning' );
+            }
+        }
+
+        $this->plugin->save_product_snapshot( $products );
+    }
+}

--- a/lotuslisans-reseller/includes/class-lotuslisans-api-client.php
+++ b/lotuslisans-reseller/includes/class-lotuslisans-api-client.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * API client wrapper.
+ *
+ * @package LotusLisansReseller
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class LotusLisans_API_Client {
+
+    /**
+     * API base URL.
+     */
+    const BASE_URL = 'https://partner.lotuslisans.com.tr';
+
+    /**
+     * Plugin instance.
+     *
+     * @var LotusLisans_Reseller_Plugin
+     */
+    protected $plugin;
+
+    /**
+     * Constructor.
+     *
+     * @param LotusLisans_Reseller_Plugin $plugin Plugin instance.
+     */
+    public function __construct( LotusLisans_Reseller_Plugin $plugin ) {
+        $this->plugin = $plugin;
+    }
+
+    /**
+     * Fetch authenticated user details.
+     *
+     * @return array|WP_Error
+     */
+    public function get_user() {
+        $response = $this->request( 'GET', '/api/user' );
+
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+
+        if ( isset( $response['data'] ) ) {
+            $this->plugin->set_cached_balance( $response['data'] );
+        }
+
+        return $response;
+    }
+
+    /**
+     * Fetch product list.
+     *
+     * @return array|WP_Error
+     */
+    public function get_products() {
+        return $this->request( 'GET', '/api/products' );
+    }
+
+    /**
+     * Perform API request.
+     *
+     * @param string $method   HTTP method.
+     * @param string $endpoint Endpoint path.
+     * @param array  $args     Optional args.
+     *
+     * @return array|WP_Error
+     */
+    public function request( $method, $endpoint, array $args = array() ) {
+        $api_key = $this->plugin->get_api_key();
+
+        if ( empty( $api_key ) ) {
+            return new WP_Error( 'lotuslisans_missing_key', __( 'Lütfen önce API anahtarınızı kaydedin.', 'lotuslisans-reseller' ) );
+        }
+
+        $url = trailingslashit( self::BASE_URL ) . ltrim( $endpoint, '/' );
+        $url = add_query_arg( array( 'apikey' => rawurlencode( $api_key ) ), $url );
+
+        $request_args = array(
+            'method'  => $method,
+            'headers' => array(
+                'Accept'     => 'application/json',
+                'X-API-Key'  => $api_key,
+            ),
+            'timeout' => 20,
+        );
+
+        if ( isset( $args['body'] ) ) {
+            $request_args['body']    = wp_json_encode( $args['body'] );
+            $request_args['headers']['Content-Type'] = 'application/json';
+        }
+
+        $http_response = wp_remote_request( $url, $request_args );
+
+        if ( is_wp_error( $http_response ) ) {
+            return $http_response;
+        }
+
+        $code = wp_remote_retrieve_response_code( $http_response );
+        $body = wp_remote_retrieve_body( $http_response );
+
+        $data = json_decode( $body, true );
+        if ( null === $data && JSON_ERROR_NONE !== json_last_error() ) {
+            return new WP_Error( 'lotuslisans_invalid_response', __( 'API yanıtı çözümlenemedi.', 'lotuslisans-reseller' ) );
+        }
+
+        if ( $code >= 200 && $code < 300 ) {
+            return $data;
+        }
+
+        $message = isset( $data['message'] ) ? $data['message'] : __( 'Bilinmeyen API hatası oluştu.', 'lotuslisans-reseller' );
+
+        return new WP_Error( 'lotuslisans_api_error', $message, array( 'status' => $code ) );
+    }
+}

--- a/lotuslisans-reseller/includes/class-lotuslisans-reseller-plugin.php
+++ b/lotuslisans-reseller/includes/class-lotuslisans-reseller-plugin.php
@@ -1,0 +1,351 @@
+<?php
+/**
+ * Main plugin bootstrap.
+ *
+ * @package LotusLisansReseller
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+require_once LOTUSLISANS_RESELLER_PATH . 'includes/class-lotuslisans-api-client.php';
+require_once LOTUSLISANS_RESELLER_PATH . 'includes/class-lotuslisans-admin.php';
+
+class LotusLisans_Reseller_Plugin {
+
+    const OPTION_KEY        = 'lotuslisans_reseller_options';
+    const LICENSE_OPTION    = 'lotuslisans_reseller_license_host';
+    const PRODUCTS_OPTION   = 'lotuslisans_reseller_last_products';
+    const NOTICE_TRANSIENT  = 'lotuslisans_reseller_notice_buffer';
+    const BALANCE_TRANSIENT = 'lotuslisans_reseller_balance_cache';
+
+    /**
+     * Plugin instance.
+     *
+     * @var LotusLisans_Reseller_Plugin|null
+     */
+    protected static $instance = null;
+
+    /**
+     * API client.
+     *
+     * @var LotusLisans_API_Client
+     */
+    protected $api_client;
+
+    /**
+     * Admin handler.
+     *
+     * @var LotusLisans_Admin
+     */
+    protected $admin;
+
+    /**
+     * Plugin basename.
+     *
+     * @var string
+     */
+    protected $plugin_basename;
+
+    /**
+     * Singleton bootstrap.
+     */
+    public static function instance() {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * Constructor.
+     */
+    protected function __construct() {
+        $this->plugin_basename = plugin_basename( LOTUSLISANS_RESELLER_FILE );
+        $this->api_client      = new LotusLisans_API_Client( $this );
+        $this->admin           = new LotusLisans_Admin( $this, $this->api_client );
+
+        register_activation_hook( LOTUSLISANS_RESELLER_FILE, array( $this, 'activate' ) );
+
+        add_action( 'plugins_loaded', array( $this, 'maybe_load_textdomain' ) );
+        add_action( 'plugins_loaded', array( $this, 'enforce_license' ), 1 );
+        add_action( 'admin_init', array( $this, 'register_settings' ) );
+        add_action( 'admin_notices', array( $this, 'render_buffered_notices' ) );
+        add_action( 'admin_bar_menu', array( $this, 'register_admin_bar_nodes' ), 100 );
+    }
+
+    /**
+     * Get plugin options.
+     *
+     * @return array
+     */
+    public function get_options() {
+        $defaults = array(
+            'api_key' => '',
+        );
+
+        $options = get_option( self::OPTION_KEY, array() );
+
+        if ( ! is_array( $options ) ) {
+            $options = array();
+        }
+
+        return wp_parse_args( $options, $defaults );
+    }
+
+    /**
+     * Update plugin options.
+     *
+     * @param array $options Options to update.
+     */
+    public function update_options( array $options ) {
+        update_option( self::OPTION_KEY, $options );
+    }
+
+    /**
+     * Retrieve the stored API key.
+     *
+     * @return string
+     */
+    public function get_api_key() {
+        $options = $this->get_options();
+
+        return isset( $options['api_key'] ) ? $options['api_key'] : '';
+    }
+
+    /**
+     * Register plugin settings.
+     */
+    public function register_settings() {
+        register_setting( 'lotuslisans_reseller_settings', self::OPTION_KEY, array( $this, 'sanitize_options' ) );
+    }
+
+    /**
+     * Sanitize options.
+     *
+     * @param array $options Options to sanitize.
+     *
+     * @return array
+     */
+    public function sanitize_options( $options ) {
+        $sanitized = array();
+
+        if ( isset( $options['api_key'] ) ) {
+            $sanitized['api_key'] = sanitize_text_field( $options['api_key'] );
+        }
+
+        return $sanitized;
+    }
+
+    /**
+     * Activation callback.
+     */
+    public function activate() {
+        $current_host = $this->get_current_host();
+        update_option( self::LICENSE_OPTION, $current_host, false );
+    }
+
+    /**
+     * Enforce domain license.
+     */
+    public function enforce_license() {
+        if ( wp_doing_ajax() ) {
+            return;
+        }
+
+        $stored_host = get_option( self::LICENSE_OPTION );
+        $current_host = $this->get_current_host();
+
+        if ( empty( $stored_host ) ) {
+            update_option( self::LICENSE_OPTION, $current_host, false );
+            return;
+        }
+
+        if ( hash_equals( $stored_host, $current_host ) ) {
+            return;
+        }
+
+        if ( is_admin() && current_user_can( 'activate_plugins' ) ) {
+            require_once ABSPATH . 'wp-admin/includes/plugin.php';
+            deactivate_plugins( $this->plugin_basename );
+            add_action(
+                'admin_notices',
+                function() use ( $stored_host, $current_host ) {
+                    printf(
+                        '<div class="notice notice-error"><p>%s</p></div>',
+                        esc_html( sprintf(
+                            /* translators: 1: stored host 2: current host */
+                            __( 'LotusLisans Reseller eklentisi bu alan adına lisanslı: %1$s. Mevcut alan adı (%2$s) ile eşleşmediği için eklenti devre dışı bırakıldı.', 'lotuslisans-reseller' ),
+                            $stored_host,
+                            $current_host
+                        ) )
+                    );
+                }
+            );
+        }
+    }
+
+    /**
+     * Get current site host.
+     *
+     * @return string
+     */
+    public function get_current_host() {
+        $home_url = home_url();
+        $host     = wp_parse_url( $home_url, PHP_URL_HOST );
+
+        return strtolower( (string) $host );
+    }
+
+    /**
+     * Load plugin textdomain.
+     */
+    public function maybe_load_textdomain() {
+        load_plugin_textdomain( 'lotuslisans-reseller', false, dirname( $this->plugin_basename ) . '/languages' );
+    }
+
+    /**
+     * Store product snapshot for change detection.
+     *
+     * @param array $products Products array.
+     */
+    public function save_product_snapshot( array $products ) {
+        update_option( self::PRODUCTS_OPTION, $products, false );
+    }
+
+    /**
+     * Retrieve stored snapshot of products.
+     *
+     * @return array
+     */
+    public function get_product_snapshot() {
+        $products = get_option( self::PRODUCTS_OPTION, array() );
+
+        return is_array( $products ) ? $products : array();
+    }
+
+    /**
+     * Buffer an admin notice to display later.
+     *
+     * @param string $message Message content.
+     * @param string $type    Notice type.
+     */
+    public function buffer_notice( $message, $type = 'info' ) {
+        $notices   = get_transient( self::NOTICE_TRANSIENT );
+        $notices   = is_array( $notices ) ? $notices : array();
+        $notices[] = array(
+            'message' => wp_kses_post( $message ),
+            'type'    => sanitize_html_class( $type ),
+        );
+
+        set_transient( self::NOTICE_TRANSIENT, $notices, MINUTE_IN_SECONDS * 30 );
+    }
+
+    /**
+     * Render buffered notices.
+     */
+    public function render_buffered_notices() {
+        $notices = get_transient( self::NOTICE_TRANSIENT );
+        if ( empty( $notices ) || ! is_array( $notices ) ) {
+            return;
+        }
+
+        delete_transient( self::NOTICE_TRANSIENT );
+
+        foreach ( $notices as $notice ) {
+            $type    = isset( $notice['type'] ) ? $notice['type'] : 'info';
+            $message = isset( $notice['message'] ) ? $notice['message'] : '';
+
+            printf( '<div class="notice notice-%1$s"><p>%2$s</p></div>', esc_attr( $type ), $message );
+        }
+    }
+
+    /**
+     * Update cached balance data.
+     *
+     * @param array $data Balance payload.
+     */
+    public function set_cached_balance( array $data ) {
+        set_transient( self::BALANCE_TRANSIENT, $data, MINUTE_IN_SECONDS * 15 );
+    }
+
+    /**
+     * Retrieve cached balance data.
+     *
+     * @return array|null
+     */
+    public function get_cached_balance() {
+        $data = get_transient( self::BALANCE_TRANSIENT );
+
+        return is_array( $data ) ? $data : null;
+    }
+
+    /**
+     * Register admin bar entries for balance and notifications.
+     *
+     * @param WP_Admin_Bar $admin_bar Admin bar instance.
+     */
+    public function register_admin_bar_nodes( $admin_bar ) {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+
+        $balance_data = $this->get_cached_balance();
+
+        if ( null === $balance_data && ! empty( $this->get_api_key() ) ) {
+            $response = $this->api_client()->get_user();
+            if ( ! is_wp_error( $response ) && isset( $response['data'] ) ) {
+                $balance_data = $response['data'];
+            }
+        }
+        $balance_text = __( 'LotusLisans Bakiye', 'lotuslisans-reseller' );
+
+        if ( null !== $balance_data && isset( $balance_data['credit'] ) ) {
+            $balance_text = sprintf(
+                __( 'LotusLisans Bakiye: %s', 'lotuslisans-reseller' ),
+                esc_html( $balance_data['credit'] )
+            );
+        }
+
+        $admin_bar->add_menu(
+            array(
+                'id'    => 'lotuslisans-balance',
+                'title' => esc_html( $balance_text ),
+                'href'  => admin_url( 'admin.php?page=lotuslisans-reseller' ),
+                'meta'  => array( 'title' => __( 'LotusLisans API Ayarları', 'lotuslisans-reseller' ) ),
+            )
+        );
+
+        $notices = get_transient( self::NOTICE_TRANSIENT );
+        if ( ! empty( $notices ) && is_array( $notices ) ) {
+            $admin_bar->add_menu(
+                array(
+                    'id'     => 'lotuslisans-alerts',
+                    'parent' => 'top-secondary',
+                    'title'  => __( 'LotusLisans Bildirimleri', 'lotuslisans-reseller' ),
+                    'href'   => admin_url( 'admin.php?page=lotuslisans-reseller' ),
+                )
+            );
+        }
+    }
+
+    /**
+     * Provide access to the admin handler.
+     *
+     * @return LotusLisans_Admin
+     */
+    public function admin() {
+        return $this->admin;
+    }
+
+    /**
+     * Provide access to the API client.
+     *
+     * @return LotusLisans_API_Client
+     */
+    public function api_client() {
+        return $this->api_client;
+    }
+}

--- a/lotuslisans-reseller/lotuslisans-reseller.php
+++ b/lotuslisans-reseller/lotuslisans-reseller.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Plugin Name: LotusLisans Reseller for WooCommerce
+ * Plugin URI: https://partner.lotuslisans.com.tr/
+ * Description: WooCommerce entegrasyonu ile LotusLisans ürünlerini yönetin.
+ * Version: 1.0.0
+ * Author: LotusLisans Entegrasyon
+ * License: GPLv2 or later
+ * Text Domain: lotuslisans-reseller
+ * Domain Path: /languages
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! defined( 'LOTUSLISANS_RESELLER_FILE' ) ) {
+    define( 'LOTUSLISANS_RESELLER_FILE', __FILE__ );
+}
+
+define( 'LOTUSLISANS_RESELLER_PATH', plugin_dir_path( LOTUSLISANS_RESELLER_FILE ) );
+define( 'LOTUSLISANS_RESELLER_URL', plugin_dir_url( LOTUSLISANS_RESELLER_FILE ) );
+define( 'LOTUSLISANS_RESELLER_VERSION', '1.0.0' );
+
+require_once LOTUSLISANS_RESELLER_PATH . 'includes/class-lotuslisans-reseller-plugin.php';
+
+function lotuslisans_reseller() {
+    return LotusLisans_Reseller_Plugin::instance();
+}
+
+lotuslisans_reseller();


### PR DESCRIPTION
## Summary
- add a LotusLisans Reseller plugin skeleton with domain-based licensing and option storage
- integrate the partner.lotuslisans.com.tr API for balance checks and product imports into WooCommerce drafts
- expose admin UX with connection testing, balance shortcut, and change notifications

## Testing
- php -l lotuslisans-reseller/lotuslisans-reseller.php
- php -l lotuslisans-reseller/includes/class-lotuslisans-reseller-plugin.php
- php -l lotuslisans-reseller/includes/class-lotuslisans-api-client.php
- php -l lotuslisans-reseller/includes/class-lotuslisans-admin.php


------
https://chatgpt.com/codex/tasks/task_b_68e552ccccd4832181cb6b1c6557af1b