### PR TITLE
Guard license option constant access

### DIFF
--- a/lotuslisans-reseller/assets/css/admin.css
+++ b/lotuslisans-reseller/assets/css/admin.css
@@ -1,0 +1,17 @@
+.lotuslisans-reseller .lotuslisans-test-result {
+    margin-left: 10px;
+    font-weight: 600;
+}
+
+.lotuslisans-reseller .lotuslisans-test-result.success {
+    color: #1d9d5f;
+}
+
+.lotuslisans-reseller .lotuslisans-test-result.error {
+    color: #d63638;
+}
+
+.lotuslisans-reseller .lotuslisans-sync-summary {
+    list-style: disc;
+    margin-left: 20px;
+}

--- a/lotuslisans-reseller/assets/js/admin.js
+++ b/lotuslisans-reseller/assets/js/admin.js
@@ -1,0 +1,42 @@
+(function($){
+    'use strict';
+
+    $(function(){
+        var $button = $('#lotuslisans-test-connection');
+        if ( !$button.length ) {
+            return;
+        }
+
+        var $result = $('.lotuslisans-test-result');
+
+        $button.on('click', function(event){
+            event.preventDefault();
+
+            if ( typeof lotuslisansReseller === 'undefined' ) {
+                return;
+            }
+
+            $button.prop('disabled', true);
+            $result.removeClass('error success').text(lotuslisansReseller.testing);
+
+            $.post(
+                lotuslisansReseller.ajaxUrl,
+                {
+                    action: 'lotuslisans_test_connection',
+                    nonce: lotuslisansReseller.nonce
+                }
+            ).done(function(response){
+                if ( response && response.success ) {
+                    $result.addClass('success').text(response.data);
+                } else {
+                    var message = response && response.data ? response.data : lotuslisansReseller.error;
+                    $result.addClass('error').text(message);
+                }
+            }).fail(function(){
+                $result.addClass('error').text(lotuslisansReseller.error);
+            }).always(function(){
+                $button.prop('disabled', false);
+            });
+        });
+    });
+})(jQuery);

--- a/lotuslisans-reseller/includes/class-lotuslisans-admin.php
+++ b/lotuslisans-reseller/includes/class-lotuslisans-admin.php
@@ -1,0 +1,452 @@
+<?php
+/**
+ * Admin functionality.
+ *
+ * @package LotusLisansReseller
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class LotusLisans_Admin {
+
+    /**
+     * Plugin instance.
+     *
+     * @var LotusLisans_Reseller_Plugin
+     */
+    protected $plugin;
+
+    /**
+     * API client.
+     *
+     * @var LotusLisans_API_Client
+     */
+    protected $api_client;
+
+    /**
+     * Constructor.
+     *
+     * @param LotusLisans_Reseller_Plugin $plugin    Plugin instance.
+     * @param LotusLisans_API_Client      $api_client API client.
+     */
+    public function __construct( LotusLisans_Reseller_Plugin $plugin, LotusLisans_API_Client $api_client ) {
+        $this->plugin     = $plugin;
+        $this->api_client = $api_client;
+
+        add_action( 'admin_menu', array( $this, 'register_menu' ) );
+        add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+        add_action( 'wp_ajax_lotuslisans_test_connection', array( $this, 'ajax_test_connection' ) );
+        add_action( 'admin_post_lotuslisans_import_products', array( $this, 'handle_import_products' ) );
+    }
+
+    /**
+     * Register plugin admin menu.
+     */
+    public function register_menu() {
+        add_menu_page(
+            __( 'LotusLisans API', 'lotuslisans-reseller' ),
+            __( 'Reseller - API', 'lotuslisans-reseller' ),
+            'manage_options',
+            'lotuslisans-reseller',
+            array( $this, 'render_settings_page' ),
+            'dashicons-rest-api',
+            58
+        );
+    }
+
+    /**
+     * Enqueue admin assets.
+     *
+     * @param string $hook Current page hook.
+     */
+    public function enqueue_assets( $hook ) {
+        if ( 'toplevel_page_lotuslisans-reseller' !== $hook ) {
+            return;
+        }
+
+        wp_enqueue_style(
+            'lotuslisans-reseller-admin',
+            LOTUSLISANS_RESELLER_URL . 'assets/css/admin.css',
+            array(),
+            LOTUSLISANS_RESELLER_VERSION
+        );
+
+        wp_enqueue_script(
+            'lotuslisans-reseller-admin',
+            LOTUSLISANS_RESELLER_URL . 'assets/js/admin.js',
+            array( 'jquery' ),
+            LOTUSLISANS_RESELLER_VERSION,
+            true
+        );
+
+        wp_localize_script(
+            'lotuslisans-reseller-admin',
+            'lotuslisansReseller',
+            array(
+                'ajaxUrl'  => admin_url( 'admin-ajax.php' ),
+                'nonce'    => wp_create_nonce( 'lotuslisans_test_connection' ),
+                'testing'  => __( 'Bağlantı test ediliyor...', 'lotuslisans-reseller' ),
+                'error'    => __( 'Beklenmeyen bir hata oluştu.', 'lotuslisans-reseller' ),
+                'success'  => __( 'Bağlantı başarılı.', 'lotuslisans-reseller' ),
+            )
+        );
+    }
+
+    /**
+     * Render settings page.
+     */
+    public function render_settings_page() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+
+        $options  = $this->plugin->get_options();
+        $api_key  = isset( $options['api_key'] ) ? $options['api_key'] : '';
+        $balance  = $this->plugin->get_cached_balance();
+        $snapshot = $this->plugin->get_product_snapshot();
+        ?>
+        <div class="wrap lotuslisans-reseller">
+            <h1><?php esc_html_e( 'LotusLisans API Ayarları', 'lotuslisans-reseller' ); ?></h1>
+            <form method="post" action="options.php">
+                <?php
+                settings_fields( 'lotuslisans_reseller_settings' );
+                ?>
+                <table class="form-table" role="presentation">
+                    <tbody>
+                        <tr>
+                            <th scope="row">
+                                <label for="lotuslisans-reseller-api-key"><?php esc_html_e( 'API Anahtarı', 'lotuslisans-reseller' ); ?></label>
+                            </th>
+                            <td>
+                                <input type="text" class="regular-text" id="lotuslisans-reseller-api-key" name="<?php echo esc_attr( LotusLisans_Reseller_Plugin::OPTION_KEY ); ?>[api_key]" value="<?php echo esc_attr( $api_key ); ?>" autocomplete="off" />
+                                <p class="description"><?php esc_html_e( 'LotusLisans panelinizden aldığınız API anahtarını giriniz.', 'lotuslisans-reseller' ); ?></p>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+                <?php submit_button( __( 'Kaydet', 'lotuslisans-reseller' ) ); ?>
+            </form>
+
+            <hr />
+
+            <h2><?php esc_html_e( 'Bağlantı Yönetimi', 'lotuslisans-reseller' ); ?></h2>
+            <p>
+                <button type="button" class="button button-secondary" id="lotuslisans-test-connection">
+                    <?php esc_html_e( 'Bağlantıyı Test Et', 'lotuslisans-reseller' ); ?>
+                </button>
+                <span class="lotuslisans-test-result" aria-live="polite"></span>
+            </p>
+
+            <?php if ( $balance && isset( $balance['credit'] ) ) : ?>
+                <div class="notice notice-success inline">
+                    <p>
+                        <?php
+                        printf(
+                            /* translators: %s: balance amount */
+                            esc_html__( 'Güncel LotusLisans bakiyeniz: %s', 'lotuslisans-reseller' ),
+                            esc_html( $balance['credit'] )
+                        );
+                        ?>
+                    </p>
+                </div>
+            <?php endif; ?>
+
+            <hr />
+
+            <h2><?php esc_html_e( 'Ürün Yönetimi', 'lotuslisans-reseller' ); ?></h2>
+            <?php if ( ! class_exists( 'WooCommerce' ) ) : ?>
+                <div class="notice notice-error inline"><p><?php esc_html_e( 'WooCommerce eklentisi etkin değil. Lütfen WooCommerce kurulumu olmadan ürün içe aktarımı yapmayınız.', 'lotuslisans-reseller' ); ?></p></div>
+            <?php endif; ?>
+            <form method="post" action="<?php echo esc_url( admin_url( 'admin-post.php' ) ); ?>">
+                <?php wp_nonce_field( 'lotuslisans_import_products' ); ?>
+                <input type="hidden" name="action" value="lotuslisans_import_products" />
+                <?php submit_button( __( 'Tüm Ürünleri WooCommerce Taslaklarına Aktar', 'lotuslisans-reseller' ), 'primary', 'lotuslisans-import-products' ); ?>
+            </form>
+
+            <?php if ( ! empty( $snapshot ) ) : ?>
+                <h3><?php esc_html_e( 'Son Senkronizasyon Özeti', 'lotuslisans-reseller' ); ?></h3>
+                <p><?php esc_html_e( 'Aşağıda son alınan ürün verilerinden bazı bilgiler yer alıyor.', 'lotuslisans-reseller' ); ?></p>
+                <ul class="lotuslisans-sync-summary">
+                    <li><?php printf( esc_html__( 'Ürün sayısı: %d', 'lotuslisans-reseller' ), count( $snapshot ) ); ?></li>
+                </ul>
+            <?php endif; ?>
+        </div>
+        <?php
+    }
+
+    /**
+     * AJAX callback for testing the API connection.
+     */
+    public function ajax_test_connection() {
+        check_ajax_referer( 'lotuslisans_test_connection', 'nonce' );
+
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( __( 'Yetkiniz bulunmuyor.', 'lotuslisans-reseller' ) );
+        }
+
+        $response = $this->api_client->get_user();
+
+        if ( is_wp_error( $response ) ) {
+            wp_send_json_error( $response->get_error_message() );
+        }
+
+        $message = __( 'Bağlantı başarılı.', 'lotuslisans-reseller' );
+
+        if ( isset( $response['data']['credit'] ) ) {
+            $message = sprintf(
+                /* translators: %s: credit balance */
+                __( 'Bağlantı başarılı. Güncel bakiyeniz: %s', 'lotuslisans-reseller' ),
+                esc_html( $response['data']['credit'] )
+            );
+        }
+
+        wp_send_json_success( $message );
+    }
+
+    /**
+     * Handle product import submission.
+     */
+    public function handle_import_products() {
+        if ( ! current_user_can( 'manage_woocommerce' ) && ! current_user_can( 'manage_options' ) ) {
+            wp_die( esc_html__( 'Bu işlem için izniniz yok.', 'lotuslisans-reseller' ) );
+        }
+
+        check_admin_referer( 'lotuslisans_import_products' );
+
+        $products_response = $this->api_client->get_products();
+
+        if ( is_wp_error( $products_response ) ) {
+            $this->plugin->buffer_notice( $products_response->get_error_message(), 'error' );
+            wp_safe_redirect( wp_get_referer() ? wp_get_referer() : admin_url( 'admin.php?page=lotuslisans-reseller' ) );
+            exit;
+        }
+
+        $products = isset( $products_response['data'] ) && is_array( $products_response['data'] ) ? $products_response['data'] : array();
+
+        $result = $this->import_products( $products );
+
+        $this->handle_product_change_notifications( $products );
+
+        if ( $result['created'] > 0 || $result['updated'] > 0 ) {
+            $this->plugin->buffer_notice(
+                sprintf(
+                    /* translators: 1: created count 2: updated count */
+                    esc_html__( '%1$d yeni ürün taslak olarak oluşturuldu, %2$d ürün güncellendi.', 'lotuslisans-reseller' ),
+                    $result['created'],
+                    $result['updated']
+                ),
+                'success'
+            );
+        } else {
+            $this->plugin->buffer_notice( esc_html__( 'İçe aktarılacak yeni ürün bulunamadı.', 'lotuslisans-reseller' ), 'info' );
+        }
+
+        wp_safe_redirect( wp_get_referer() ? wp_get_referer() : admin_url( 'admin.php?page=lotuslisans-reseller' ) );
+        exit;
+    }
+
+    /**
+     * Import products into WooCommerce.
+     *
+     * @param array $products API product list.
+     *
+     * @return array
+     */
+    protected function import_products( array $products ) {
+        $results = array(
+            'created' => 0,
+            'updated' => 0,
+        );
+
+        if ( empty( $products ) ) {
+            return $results;
+        }
+
+        if ( ! class_exists( 'WooCommerce' ) ) {
+            $this->plugin->buffer_notice( esc_html__( 'WooCommerce bulunamadı. Ürünler içe aktarılamadı.', 'lotuslisans-reseller' ), 'error' );
+            return $results;
+        }
+
+        foreach ( $products as $product ) {
+            if ( empty( $product['id'] ) ) {
+                continue;
+            }
+
+            $existing_id = $this->find_product_by_remote_id( $product['id'] );
+
+            if ( $existing_id ) {
+                $updated = $this->update_existing_product( $existing_id, $product );
+                if ( $updated ) {
+                    $results['updated']++;
+                }
+                continue;
+            }
+
+            $created = $this->create_product( $product );
+            if ( $created ) {
+                $results['created']++;
+            }
+        }
+
+        return $results;
+    }
+
+    /**
+     * Find a local product by remote ID.
+     *
+     * @param int $remote_id Remote product ID.
+     *
+     * @return int|false
+     */
+    protected function find_product_by_remote_id( $remote_id ) {
+        $query = new WP_Query(
+            array(
+                'post_type'      => 'product',
+                'posts_per_page' => 1,
+                'post_status'    => 'any',
+                'fields'         => 'ids',
+                'meta_key'       => '_lotuslisans_product_id',
+                'meta_value'     => $remote_id,
+            )
+        );
+
+        if ( empty( $query->posts ) ) {
+            return false;
+        }
+
+        return (int) $query->posts[0];
+    }
+
+    /**
+     * Create WooCommerce product draft.
+     *
+     * @param array $product Product data.
+     *
+     * @return bool
+     */
+    protected function create_product( array $product ) {
+        $post_id = wp_insert_post(
+            array(
+                'post_title'   => isset( $product['title'] ) ? sanitize_text_field( $product['title'] ) : __( 'LotusLisans Ürünü', 'lotuslisans-reseller' ),
+                'post_content' => isset( $product['content'] ) ? wp_kses_post( $product['content'] ) : '',
+                'post_status'  => 'draft',
+                'post_type'    => 'product',
+            ),
+            true
+        );
+
+        if ( is_wp_error( $post_id ) ) {
+            $this->plugin->buffer_notice( $post_id->get_error_message(), 'error' );
+            return false;
+        }
+
+        $this->update_product_meta( $post_id, $product );
+
+        return true;
+    }
+
+    /**
+     * Update an existing product.
+     *
+     * @param int   $post_id Product ID.
+     * @param array $product Product data.
+     *
+     * @return bool
+     */
+    protected function update_existing_product( $post_id, array $product ) {
+        $updated_post = array(
+            'ID'           => $post_id,
+            'post_title'   => isset( $product['title'] ) ? sanitize_text_field( $product['title'] ) : get_the_title( $post_id ),
+            'post_content' => isset( $product['content'] ) ? wp_kses_post( $product['content'] ) : get_post_field( 'post_content', $post_id ),
+        );
+
+        $result = wp_update_post( $updated_post, true );
+
+        if ( is_wp_error( $result ) ) {
+            $this->plugin->buffer_notice( $result->get_error_message(), 'error' );
+            return false;
+        }
+
+        $this->update_product_meta( $post_id, $product );
+
+        return true;
+    }
+
+    /**
+     * Update WooCommerce product meta information.
+     *
+     * @param int   $post_id Product ID.
+     * @param array $product Product data.
+     */
+    protected function update_product_meta( $post_id, array $product ) {
+        if ( isset( $product['amount'] ) ) {
+            $price = function_exists( 'wc_format_decimal' ) ? wc_format_decimal( $product['amount'] ) : sanitize_text_field( $product['amount'] );
+            update_post_meta( $post_id, '_regular_price', $price );
+            update_post_meta( $post_id, '_price', $price );
+        }
+
+        $available = isset( $product['available'] ) ? (bool) $product['available'] : false;
+        update_post_meta( $post_id, '_stock_status', $available ? 'instock' : 'onbackorder' );
+        update_post_meta( $post_id, '_manage_stock', 'no' );
+        update_post_meta( $post_id, '_lotuslisans_product_id', (int) $product['id'] );
+        update_post_meta( $post_id, '_lotuslisans_available', $available ? 'yes' : 'no' );
+        update_post_meta( $post_id, '_virtual', 'yes' );
+        update_post_meta( $post_id, '_downloadable', 'no' );
+    }
+
+    /**
+     * Handle notifications for product changes.
+     *
+     * @param array $products Latest product payload.
+     */
+    protected function handle_product_change_notifications( array $products ) {
+        $previous = $this->plugin->get_product_snapshot();
+        $changes  = array();
+
+        $indexed_previous = array();
+        foreach ( $previous as $product ) {
+            if ( isset( $product['id'] ) ) {
+                $indexed_previous[ $product['id'] ] = $product;
+            }
+        }
+
+        foreach ( $products as $product ) {
+            if ( ! isset( $product['id'] ) ) {
+                continue;
+            }
+
+            $id = (int) $product['id'];
+
+            if ( ! isset( $indexed_previous[ $id ] ) ) {
+                $changes[] = sprintf(
+                    /* translators: %s: product title */
+                    esc_html__( 'Yeni ürün bulundu: %s', 'lotuslisans-reseller' ),
+                    isset( $product['title'] ) ? esc_html( $product['title'] ) : $id
+                );
+                continue;
+            }
+
+            $previous_product = $indexed_previous[ $id ];
+
+            if ( isset( $previous_product['amount'], $product['amount'] ) && $previous_product['amount'] !== $product['amount'] ) {
+                $changes[] = sprintf(
+                    /* translators: 1: product title 2: old price 3: new price */
+                    esc_html__( '%1$s fiyatı güncellendi: %2$s → %3$s', 'lotuslisans-reseller' ),
+                    isset( $product['title'] ) ? esc_html( $product['title'] ) : $id,
+                    esc_html( $previous_product['amount'] ),
+                    esc_html( $product['amount'] )
+                );
+            }
+        }
+
+        if ( ! empty( $changes ) ) {
+            foreach ( $changes as $change ) {
+                $this->plugin->buffer_notice( $change, 'warning' );
+            }
+        }
+
+        $this->plugin->save_product_snapshot( $products );
+    }
+}

--- a/lotuslisans-reseller/includes/class-lotuslisans-api-client.php
+++ b/lotuslisans-reseller/includes/class-lotuslisans-api-client.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * API client wrapper.
+ *
+ * @package LotusLisansReseller
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class LotusLisans_API_Client {
+
+    /**
+     * API base URL.
+     */
+    const BASE_URL = 'https://partner.lotuslisans.com.tr';
+
+    /**
+     * Plugin instance.
+     *
+     * @var LotusLisans_Reseller_Plugin
+     */
+    protected $plugin;
+
+    /**
+     * Constructor.
+     *
+     * @param LotusLisans_Reseller_Plugin $plugin Plugin instance.
+     */
+    public function __construct( LotusLisans_Reseller_Plugin $plugin ) {
+        $this->plugin = $plugin;
+    }
+
+    /**
+     * Fetch authenticated user details.
+     *
+     * @return array|WP_Error
+     */
+    public function get_user() {
+        $response = $this->request( 'GET', '/api/user' );
+
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+
+        if ( isset( $response['data'] ) ) {
+            $this->plugin->set_cached_balance( $response['data'] );
+        }
+
+        return $response;
+    }
+
+    /**
+     * Fetch product list.
+     *
+     * @return array|WP_Error
+     */
+    public function get_products() {
+        return $this->request( 'GET', '/api/products' );
+    }
+
+    /**
+     * Perform API request.
+     *
+     * @param string $method   HTTP method.
+     * @param string $endpoint Endpoint path.
+     * @param array  $args     Optional args.
+     *
+     * @return array|WP_Error
+     */
+    public function request( $method, $endpoint, array $args = array() ) {
+        $api_key = $this->plugin->get_api_key();
+
+        if ( empty( $api_key ) ) {
+            return new WP_Error( 'lotuslisans_missing_key', __( 'Lütfen önce API anahtarınızı kaydedin.', 'lotuslisans-reseller' ) );
+        }
+
+        $url = trailingslashit( self::BASE_URL ) . ltrim( $endpoint, '/' );
+        $url = add_query_arg( array( 'apikey' => rawurlencode( $api_key ) ), $url );
+
+        $request_args = array(
+            'method'  => $method,
+            'headers' => array(
+                'Accept'     => 'application/json',
+                'X-API-Key'  => $api_key,
+            ),
+            'timeout' => 20,
+        );
+
+        if ( isset( $args['body'] ) ) {
+            $request_args['body']    = wp_json_encode( $args['body'] );
+            $request_args['headers']['Content-Type'] = 'application/json';
+        }
+
+        $http_response = wp_remote_request( $url, $request_args );
+
+        if ( is_wp_error( $http_response ) ) {
+            return $http_response;
+        }
+
+        $code = wp_remote_retrieve_response_code( $http_response );
+        $body = wp_remote_retrieve_body( $http_response );
+
+        $data = json_decode( $body, true );
+        if ( null === $data && JSON_ERROR_NONE !== json_last_error() ) {
+            return new WP_Error( 'lotuslisans_invalid_response', __( 'API yanıtı çözümlenemedi.', 'lotuslisans-reseller' ) );
+        }
+
+        if ( $code >= 200 && $code < 300 ) {
+            return $data;
+        }
+
+        $message = isset( $data['message'] ) ? $data['message'] : __( 'Bilinmeyen API hatası oluştu.', 'lotuslisans-reseller' );
+
+        return new WP_Error( 'lotuslisans_api_error', $message, array( 'status' => $code ) );
+    }
+}

--- a/lotuslisans-reseller/includes/class-lotuslisans-reseller-plugin.php
+++ b/lotuslisans-reseller/includes/class-lotuslisans-reseller-plugin.php
@@ -1,0 +1,1075 @@
+<?php
+/**
+ * Main plugin bootstrap.
+ *
+ * @package LotusLisansReseller
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+require_once LOTUSLISANS_RESELLER_PATH . 'includes/class-lotuslisans-api-client.php';
+require_once LOTUSLISANS_RESELLER_PATH . 'includes/class-lotuslisans-admin.php';
+
+class LotusLisans_Reseller_Plugin {
+
+    const OPTION_KEY         = 'lotuslisans_reseller_options';
+    const LICENSE_OPTION     = 'lotuslisans_reseller_license_host';
+    const PRODUCTS_OPTION    = 'lotuslisans_reseller_last_products';
+    const NOTICE_TRANSIENT   = 'lotuslisans_reseller_notice_buffer';
+    const BALANCE_TRANSIENT  = 'lotuslisans_reseller_balance_cache';
+    const USER_API_KEY_META  = '_lotuslisans_reseller_api_key';
+    const DOCS_ENDPOINT_SLUG = 'reseller-api-docs';
+
+    /**
+     * Plugin instance.
+     *
+     * @var LotusLisans_Reseller_Plugin|null
+     */
+    protected static $instance = null;
+
+    /**
+     * API client.
+     *
+     * @var LotusLisans_API_Client
+     */
+    protected $api_client;
+
+    /**
+     * Admin handler.
+     *
+     * @var LotusLisans_Admin
+     */
+    protected $admin;
+
+    /**
+     * Plugin basename.
+     *
+     * @var string
+     */
+    protected $plugin_basename;
+
+    /**
+     * Singleton bootstrap.
+     */
+    public static function instance() {
+        if ( null === self::$instance ) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    /**
+     * Constructor.
+     */
+    protected function __construct() {
+        $this->plugin_basename = plugin_basename( LOTUSLISANS_RESELLER_FILE );
+        $this->api_client      = new LotusLisans_API_Client( $this );
+        $this->admin           = new LotusLisans_Admin( $this, $this->api_client );
+
+        register_activation_hook( LOTUSLISANS_RESELLER_FILE, array( $this, 'activate' ) );
+
+        add_action( 'plugins_loaded', array( $this, 'maybe_load_textdomain' ) );
+        add_action( 'plugins_loaded', array( $this, 'enforce_license' ), 1 );
+        add_action( 'admin_init', array( $this, 'register_settings' ) );
+        add_action( 'admin_notices', array( $this, 'render_buffered_notices' ) );
+        add_action( 'admin_bar_menu', array( $this, 'register_admin_bar_nodes' ), 100 );
+        add_action( 'init', array( __CLASS__, 'register_rewrite_endpoint' ) );
+        add_filter( 'query_vars', array( $this, 'register_query_vars' ) );
+        add_filter( 'template_include', array( $this, 'maybe_render_docs_template' ) );
+        add_action( 'rest_api_init', array( $this, 'register_rest_routes' ) );
+        add_action( 'init', array( $this, 'maybe_handle_account_actions' ) );
+        add_action( 'woocommerce_account_dashboard', array( $this, 'render_customer_api_panel' ), 25 );
+    }
+
+    /**
+     * Get plugin options.
+     *
+     * @return array
+     */
+    public function get_options() {
+        $defaults = array(
+            'api_key' => '',
+        );
+
+        $options = get_option( self::OPTION_KEY, array() );
+
+        if ( ! is_array( $options ) ) {
+            $options = array();
+        }
+
+        return wp_parse_args( $options, $defaults );
+    }
+
+    /**
+     * Update plugin options.
+     *
+     * @param array $options Options to update.
+     */
+    public function update_options( array $options ) {
+        update_option( self::OPTION_KEY, $options );
+    }
+
+    /**
+     * Retrieve the stored API key.
+     *
+     * @return string
+     */
+    public function get_api_key() {
+        $options = $this->get_options();
+
+        return isset( $options['api_key'] ) ? $options['api_key'] : '';
+    }
+
+    /**
+     * Register plugin settings.
+     */
+    public function register_settings() {
+        register_setting( 'lotuslisans_reseller_settings', self::OPTION_KEY, array( $this, 'sanitize_options' ) );
+    }
+
+    /**
+     * Sanitize options.
+     *
+     * @param array $options Options to sanitize.
+     *
+     * @return array
+     */
+    public function sanitize_options( $options ) {
+        $sanitized = array();
+
+        if ( isset( $options['api_key'] ) ) {
+            $sanitized['api_key'] = sanitize_text_field( $options['api_key'] );
+        }
+
+        return $sanitized;
+    }
+
+    /**
+     * Activation callback.
+     */
+    public function activate() {
+        $current_host = $this->get_current_host();
+        update_option( $this->get_license_option_name(), $current_host, false );
+        self::register_rewrite_endpoint();
+        flush_rewrite_rules();
+    }
+
+    /**
+     * Enforce domain license.
+     */
+    public function enforce_license() {
+        if ( wp_doing_ajax() ) {
+            return;
+        }
+
+        $stored_host = get_option( $this->get_license_option_name() );
+        $current_host = $this->get_current_host();
+
+        if ( empty( $stored_host ) ) {
+            update_option( $this->get_license_option_name(), $current_host, false );
+            return;
+        }
+
+        if ( hash_equals( $stored_host, $current_host ) ) {
+            return;
+        }
+
+        if ( is_admin() && current_user_can( 'activate_plugins' ) ) {
+            require_once ABSPATH . 'wp-admin/includes/plugin.php';
+            deactivate_plugins( $this->plugin_basename );
+            add_action(
+                'admin_notices',
+                function() use ( $stored_host, $current_host ) {
+                    printf(
+                        '<div class="notice notice-error"><p>%s</p></div>',
+                        esc_html( sprintf(
+                            /* translators: 1: stored host 2: current host */
+                            __( 'LotusLisans Reseller eklentisi bu alan adına lisanslı: %1$s. Mevcut alan adı (%2$s) ile eşleşmediği için eklenti devre dışı bırakıldı.', 'lotuslisans-reseller' ),
+                            $stored_host,
+                            $current_host
+                        ) )
+                    );
+                }
+            );
+        }
+    }
+
+    /**
+     * Retrieve the persistent option name used for license storage.
+     *
+     * Some hosting environments reported the class constant lookup failing,
+     * therefore we provide a backwards-compatible fallback to the literal
+     * option key.
+     *
+     * @return string
+     */
+    protected function get_license_option_name() {
+        if ( defined( __CLASS__ . '::LICENSE_OPTION' ) ) {
+            return self::LICENSE_OPTION;
+        }
+
+        return 'lotuslisans_reseller_license_host';
+    }
+
+    /**
+     * Get current site host.
+     *
+     * @return string
+     */
+    public function get_current_host() {
+        $home_url = home_url();
+        $host     = wp_parse_url( $home_url, PHP_URL_HOST );
+
+        return strtolower( (string) $host );
+    }
+
+    /**
+     * Load plugin textdomain.
+     */
+    public function maybe_load_textdomain() {
+        load_plugin_textdomain( 'lotuslisans-reseller', false, dirname( $this->plugin_basename ) . '/languages' );
+    }
+
+    /**
+     * Register public documentation endpoint.
+     */
+    public static function register_rewrite_endpoint() {
+        add_rewrite_endpoint( self::DOCS_ENDPOINT_SLUG, EP_ROOT | EP_PAGES );
+    }
+
+    /**
+     * Register query vars used by the plugin.
+     *
+     * @param array $vars Query vars.
+     *
+     * @return array
+     */
+    public function register_query_vars( $vars ) {
+        $vars[] = self::DOCS_ENDPOINT_SLUG;
+
+        return $vars;
+    }
+
+    /**
+     * Maybe switch the template to the API documentation view.
+     *
+     * @param string $template Current template path.
+     *
+     * @return string
+     */
+    public function maybe_render_docs_template( $template ) {
+        $docs_request = get_query_var( self::DOCS_ENDPOINT_SLUG, null );
+
+        if ( null === $docs_request ) {
+            return $template;
+        }
+
+        $docs_template = LOTUSLISANS_RESELLER_PATH . 'templates/api-docs.php';
+
+        if ( file_exists( $docs_template ) ) {
+            return $docs_template;
+        }
+
+        return $template;
+    }
+
+    /**
+     * Store product snapshot for change detection.
+     *
+     * @param array $products Products array.
+     */
+    public function save_product_snapshot( array $products ) {
+        update_option( self::PRODUCTS_OPTION, $products, false );
+    }
+
+    /**
+     * Retrieve stored snapshot of products.
+     *
+     * @return array
+     */
+    public function get_product_snapshot() {
+        $products = get_option( self::PRODUCTS_OPTION, array() );
+
+        return is_array( $products ) ? $products : array();
+    }
+
+    /**
+     * Buffer an admin notice to display later.
+     *
+     * @param string $message Message content.
+     * @param string $type    Notice type.
+     */
+    public function buffer_notice( $message, $type = 'info' ) {
+        $notices   = get_transient( self::NOTICE_TRANSIENT );
+        $notices   = is_array( $notices ) ? $notices : array();
+        $notices[] = array(
+            'message' => wp_kses_post( $message ),
+            'type'    => sanitize_html_class( $type ),
+        );
+
+        set_transient( self::NOTICE_TRANSIENT, $notices, MINUTE_IN_SECONDS * 30 );
+    }
+
+    /**
+     * Render buffered notices.
+     */
+    public function render_buffered_notices() {
+        $notices = get_transient( self::NOTICE_TRANSIENT );
+        if ( empty( $notices ) || ! is_array( $notices ) ) {
+            return;
+        }
+
+        delete_transient( self::NOTICE_TRANSIENT );
+
+        foreach ( $notices as $notice ) {
+            $type    = isset( $notice['type'] ) ? $notice['type'] : 'info';
+            $message = isset( $notice['message'] ) ? $notice['message'] : '';
+
+            printf( '<div class="notice notice-%1$s"><p>%2$s</p></div>', esc_attr( $type ), $message );
+        }
+    }
+
+    /**
+     * Update cached balance data.
+     *
+     * @param array $data Balance payload.
+     */
+    public function set_cached_balance( array $data ) {
+        set_transient( self::BALANCE_TRANSIENT, $data, MINUTE_IN_SECONDS * 15 );
+    }
+
+    /**
+     * Retrieve cached balance data.
+     *
+     * @return array|null
+     */
+    public function get_cached_balance() {
+        $data = get_transient( self::BALANCE_TRANSIENT );
+
+        return is_array( $data ) ? $data : null;
+    }
+
+    /**
+     * Register admin bar entries for balance and notifications.
+     *
+     * @param WP_Admin_Bar $admin_bar Admin bar instance.
+     */
+    public function register_admin_bar_nodes( $admin_bar ) {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return;
+        }
+
+        $balance_data = $this->get_cached_balance();
+
+        if ( null === $balance_data && ! empty( $this->get_api_key() ) ) {
+            $response = $this->api_client()->get_user();
+            if ( ! is_wp_error( $response ) && isset( $response['data'] ) ) {
+                $balance_data = $response['data'];
+            }
+        }
+        $balance_text = __( 'LotusLisans Bakiye', 'lotuslisans-reseller' );
+
+        if ( null !== $balance_data && isset( $balance_data['credit'] ) ) {
+            $balance_text = sprintf(
+                __( 'LotusLisans Bakiye: %s', 'lotuslisans-reseller' ),
+                esc_html( $balance_data['credit'] )
+            );
+        }
+
+        $admin_bar->add_menu(
+            array(
+                'id'    => 'lotuslisans-balance',
+                'title' => esc_html( $balance_text ),
+                'href'  => admin_url( 'admin.php?page=lotuslisans-reseller' ),
+                'meta'  => array( 'title' => __( 'LotusLisans API Ayarları', 'lotuslisans-reseller' ) ),
+            )
+        );
+
+        $notices = get_transient( self::NOTICE_TRANSIENT );
+        if ( ! empty( $notices ) && is_array( $notices ) ) {
+            $admin_bar->add_menu(
+                array(
+                    'id'     => 'lotuslisans-alerts',
+                    'parent' => 'top-secondary',
+                    'title'  => __( 'LotusLisans Bildirimleri', 'lotuslisans-reseller' ),
+                    'href'   => admin_url( 'admin.php?page=lotuslisans-reseller' ),
+                )
+            );
+        }
+    }
+
+    /**
+     * Retrieve the API key for a user, generating one if needed.
+     *
+     * @param int $user_id User ID.
+     *
+     * @return string
+     */
+    public function get_user_api_key( $user_id ) {
+        $user_id = absint( $user_id );
+
+        if ( $user_id <= 0 ) {
+            return '';
+        }
+
+        $existing = get_user_meta( $user_id, self::USER_API_KEY_META, true );
+
+        if ( empty( $existing ) ) {
+            return $this->generate_user_api_key( $user_id, true );
+        }
+
+        return $existing;
+    }
+
+    /**
+     * Generate and persist a new API key for a user.
+     *
+     * @param int  $user_id    User ID.
+     * @param bool $force_save Whether to force creation of a new key.
+     *
+     * @return string
+     */
+    public function generate_user_api_key( $user_id, $force_save = false ) {
+        $user_id = absint( $user_id );
+
+        if ( $user_id <= 0 ) {
+            return '';
+        }
+
+        if ( ! $force_save ) {
+            $existing = get_user_meta( $user_id, self::USER_API_KEY_META, true );
+            if ( ! empty( $existing ) ) {
+                return $existing;
+            }
+        }
+
+        $new_key = wp_generate_password( 32, false, false );
+        update_user_meta( $user_id, self::USER_API_KEY_META, $new_key );
+
+        return $new_key;
+    }
+
+    /**
+     * Handle customer-facing actions like API key regeneration.
+     */
+    public function maybe_handle_account_actions() {
+        if ( empty( $_POST['lotuslisans_action'] ) ) {
+            return;
+        }
+
+        if ( ! is_user_logged_in() ) {
+            return;
+        }
+
+        $action = sanitize_text_field( wp_unslash( $_POST['lotuslisans_action'] ) );
+
+        if ( 'regenerate_api_key' !== $action ) {
+            return;
+        }
+
+        $nonce = isset( $_POST['_lotuslisans_nonce'] ) ? sanitize_text_field( wp_unslash( $_POST['_lotuslisans_nonce'] ) ) : '';
+
+        if ( ! wp_verify_nonce( $nonce, 'lotuslisans_regenerate_api_key' ) ) {
+            if ( function_exists( 'wc_add_notice' ) ) {
+                wc_add_notice( __( 'Güvenlik doğrulaması başarısız oldu.', 'lotuslisans-reseller' ), 'error' );
+            }
+            wp_safe_redirect( $this->get_account_dashboard_url() );
+            exit;
+        }
+
+        $user_id = get_current_user_id();
+        $this->generate_user_api_key( $user_id, true );
+
+        if ( function_exists( 'wc_add_notice' ) ) {
+            wc_add_notice( __( 'API anahtarınız yenilendi.', 'lotuslisans-reseller' ), 'success' );
+        }
+
+        wp_safe_redirect( $this->get_account_dashboard_url() );
+        exit;
+    }
+
+    /**
+     * Render API details on the WooCommerce account dashboard.
+     */
+    public function render_customer_api_panel() {
+        if ( ! is_user_logged_in() ) {
+            return;
+        }
+
+        $user_id = get_current_user_id();
+        $api_key = $this->get_user_api_key( $user_id );
+
+        if ( empty( $api_key ) ) {
+            $api_key = $this->generate_user_api_key( $user_id, true );
+        }
+
+        $api_base = esc_url( rest_url( 'lotuslisans-reseller/v1' ) );
+        $docs_url = esc_url( $this->get_docs_url() );
+        ?>
+        <section class="lotuslisans-customer-api">
+            <h2><?php esc_html_e( 'Reseller API Bilgileriniz', 'lotuslisans-reseller' ); ?></h2>
+            <p><?php esc_html_e( 'Bu anahtar ile ürünleri sitenize aktarabilir ve siparişleri otomatikleştirebilirsiniz. Anahtarınızı güvende tutunuz.', 'lotuslisans-reseller' ); ?></p>
+            <table class="shop_table shop_table_responsive">
+                <tbody>
+                    <tr>
+                        <th><?php esc_html_e( 'API Temel Adresi', 'lotuslisans-reseller' ); ?></th>
+                        <td><code><?php echo esc_html( trailingslashit( $api_base ) ); ?></code></td>
+                    </tr>
+                    <tr>
+                        <th><?php esc_html_e( 'API Anahtarı', 'lotuslisans-reseller' ); ?></th>
+                        <td><code><?php echo esc_html( $api_key ); ?></code></td>
+                    </tr>
+                    <tr>
+                        <th><?php esc_html_e( 'Dokümantasyon', 'lotuslisans-reseller' ); ?></th>
+                        <td><a href="<?php echo $docs_url; ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Reseller API Dokümantasyonu', 'lotuslisans-reseller' ); ?></a></td>
+                    </tr>
+                </tbody>
+            </table>
+            <form method="post" class="lotuslisans-api-regenerate">
+                <?php wp_nonce_field( 'lotuslisans_regenerate_api_key', '_lotuslisans_nonce' ); ?>
+                <input type="hidden" name="lotuslisans_action" value="regenerate_api_key" />
+                <button type="submit" class="button" onclick="return confirm('<?php echo esc_js( __( 'Yeni bir anahtar oluşturmak üzeresiniz. Eski anahtar geçersiz hale gelecektir. Devam edilsin mi?', 'lotuslisans-reseller' ) ); ?>');">
+                    <?php esc_html_e( 'API Anahtarını Yenile', 'lotuslisans-reseller' ); ?>
+                </button>
+            </form>
+        </section>
+        <?php
+    }
+
+    /**
+     * Retrieve the reseller API documentation URL.
+     *
+     * @return string
+     */
+    public function get_docs_url() {
+        return home_url( '/' . self::DOCS_ENDPOINT_SLUG . '/' );
+    }
+
+    /**
+     * Get WooCommerce account dashboard URL.
+     *
+     * @return string
+     */
+    protected function get_account_dashboard_url() {
+        if ( function_exists( 'wc_get_account_endpoint_url' ) ) {
+            return wc_get_account_endpoint_url( 'dashboard' );
+        }
+
+        return home_url();
+    }
+
+    /**
+     * Register REST API routes used by external resellers.
+     */
+    public function register_rest_routes() {
+        register_rest_route(
+            'lotuslisans-reseller/v1',
+            '/products',
+            array(
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => array( $this, 'rest_get_products' ),
+                'permission_callback' => array( $this, 'authenticate_rest_request' ),
+                'args'                => array(
+                    'page' => array(
+                        'default'           => 1,
+                        'sanitize_callback' => 'absint',
+                    ),
+                    'per_page' => array(
+                        'default'           => 20,
+                        'sanitize_callback' => array( $this, 'sanitize_per_page' ),
+                    ),
+                    'search' => array(
+                        'sanitize_callback' => 'sanitize_text_field',
+                    ),
+                    'stock_status' => array(
+                        'sanitize_callback' => 'sanitize_text_field',
+                    ),
+                    'updated_after' => array(
+                        'sanitize_callback' => 'sanitize_text_field',
+                    ),
+                ),
+            )
+        );
+
+        register_rest_route(
+            'lotuslisans-reseller/v1',
+            '/products/(?P<id>\d+)',
+            array(
+                'methods'             => WP_REST_Server::READABLE,
+                'callback'            => array( $this, 'rest_get_single_product' ),
+                'permission_callback' => array( $this, 'authenticate_rest_request' ),
+                'args'                => array(
+                    'id' => array(
+                        'required'          => true,
+                        'sanitize_callback' => 'absint',
+                    ),
+                ),
+            )
+        );
+
+        register_rest_route(
+            'lotuslisans-reseller/v1',
+            '/orders',
+            array(
+                'methods'             => WP_REST_Server::CREATABLE,
+                'callback'            => array( $this, 'rest_create_order' ),
+                'permission_callback' => array( $this, 'authenticate_rest_request' ),
+                'args'                => array(
+                    'product_id' => array(
+                        'required'          => true,
+                        'sanitize_callback' => 'absint',
+                    ),
+                    'quantity' => array(
+                        'default'           => 1,
+                        'sanitize_callback' => 'absint',
+                    ),
+                    'customer_email' => array(
+                        'sanitize_callback' => 'sanitize_email',
+                    ),
+                    'customer_name' => array(
+                        'sanitize_callback' => 'sanitize_text_field',
+                    ),
+                    'note' => array(
+                        'sanitize_callback' => array( $this, 'sanitize_note_field' ),
+                    ),
+                ),
+            )
+        );
+    }
+
+    /**
+     * Sanitize per_page value.
+     *
+     * @param int|string $value Raw value.
+     *
+     * @return int
+     */
+    public function sanitize_per_page( $value ) {
+        $per_page = absint( $value );
+
+        if ( $per_page < 1 ) {
+            $per_page = 20;
+        }
+
+        return min( 100, $per_page );
+    }
+
+    /**
+     * Sanitize note field content.
+     *
+     * @param string $value Raw note.
+     *
+     * @return string
+     */
+    public function sanitize_note_field( $value ) {
+        return sanitize_textarea_field( $value );
+    }
+
+    /**
+     * Authenticate REST request via API key.
+     *
+     * @param WP_REST_Request $request REST request.
+     *
+     * @return bool|WP_Error
+     */
+    public function authenticate_rest_request( $request ) {
+        $api_key = $this->extract_api_key_from_request( $request );
+
+        if ( empty( $api_key ) ) {
+            return new WP_Error( 'lotuslisans_missing_key', __( 'API anahtarı gerekli.', 'lotuslisans-reseller' ), array( 'status' => 401 ) );
+        }
+
+        $user_id = $this->find_user_by_api_key( $api_key );
+
+        if ( ! $user_id ) {
+            return new WP_Error( 'lotuslisans_invalid_key', __( 'API anahtarınız doğrulanamadı.', 'lotuslisans-reseller' ), array( 'status' => 401 ) );
+        }
+
+        if ( $request instanceof WP_REST_Request ) {
+            $request->set_attribute( 'lotuslisans_user_id', $user_id );
+        }
+
+        return true;
+    }
+
+    /**
+     * Extract API key from request headers or parameters.
+     *
+     * @param WP_REST_Request $request REST request.
+     *
+     * @return string
+     */
+    protected function extract_api_key_from_request( $request ) {
+        $header_key = $request->get_header( 'X-API-Key' );
+        if ( ! empty( $header_key ) ) {
+            return sanitize_text_field( $header_key );
+        }
+
+        $param_key = $request->get_param( 'api_key' );
+        if ( ! empty( $param_key ) ) {
+            return sanitize_text_field( $param_key );
+        }
+
+        return '';
+    }
+
+    /**
+     * Find a user ID by stored API key.
+     *
+     * @param string $api_key API key.
+     *
+     * @return int
+     */
+    protected function find_user_by_api_key( $api_key ) {
+        global $wpdb;
+
+        if ( empty( $api_key ) ) {
+            return 0;
+        }
+
+        $meta_key = self::USER_API_KEY_META;
+        $user_id  = $wpdb->get_var(
+            $wpdb->prepare(
+                "SELECT user_id FROM {$wpdb->usermeta} WHERE meta_key = %s AND meta_value = %s LIMIT 1",
+                $meta_key,
+                $api_key
+            )
+        );
+
+        return $user_id ? (int) $user_id : 0;
+    }
+
+    /**
+     * Return a paginated list of WooCommerce products for API consumers.
+     *
+     * @param WP_REST_Request $request REST request.
+     *
+     * @return WP_REST_Response|WP_Error
+     */
+    public function rest_get_products( $request ) {
+        if ( ! class_exists( 'WooCommerce' ) ) {
+            return new WP_Error( 'lotuslisans_woocommerce_missing', __( 'WooCommerce etkin değil.', 'lotuslisans-reseller' ), array( 'status' => 503 ) );
+        }
+
+        $page     = max( 1, absint( $request->get_param( 'page' ) ) );
+        $per_page = $this->sanitize_per_page( $request->get_param( 'per_page' ) );
+        $search   = $request->get_param( 'search' );
+        $status   = $request->get_param( 'stock_status' );
+        $updated  = $request->get_param( 'updated_after' );
+
+        $args = array(
+            'status'   => array( 'publish' ),
+            'limit'    => $per_page,
+            'page'     => $page,
+            'paginate' => true,
+            'orderby'  => 'date',
+            'order'    => 'DESC',
+        );
+
+        if ( ! empty( $search ) ) {
+            $args['search'] = $search;
+        }
+
+        if ( ! empty( $status ) ) {
+            $args['stock_status'] = $status;
+        }
+
+        if ( ! empty( $updated ) ) {
+            $timestamp = strtotime( $updated );
+            if ( false !== $timestamp ) {
+                $args['date_query'] = array(
+                    array(
+                        'column' => 'post_modified_gmt',
+                        'after'  => gmdate( 'Y-m-d H:i:s', $timestamp ),
+                    ),
+                );
+            }
+        }
+
+        $results = wc_get_products( $args );
+
+        $products = array();
+        $total    = 0;
+        $pages    = 1;
+
+        if ( is_array( $results ) ) {
+            $products = $results;
+            $total    = count( $results );
+        } elseif ( isset( $results->products ) ) {
+            $products = $results->products;
+            $total    = isset( $results->total ) ? (int) $results->total : count( $products );
+            $pages    = isset( $results->max_num_pages ) ? (int) $results->max_num_pages : 1;
+        }
+
+        $data = array();
+
+        foreach ( $products as $product ) {
+            if ( $product && is_a( $product, 'WC_Product' ) ) {
+                $data[] = $this->format_product_for_api( $product );
+            }
+        }
+
+        $response = array(
+            'data' => $data,
+            'meta' => array(
+                'page'        => $page,
+                'per_page'    => $per_page,
+                'total'       => $total,
+                'total_pages' => $pages,
+                'currency'    => get_woocommerce_currency(),
+            ),
+        );
+
+        return rest_ensure_response( $response );
+    }
+
+    /**
+     * Format product data for external API consumers.
+     *
+     * @param WC_Product $product WooCommerce product.
+     *
+     * @return array
+     */
+    protected function format_product_for_api( $product ) {
+        if ( ! $product || ! is_a( $product, 'WC_Product' ) ) {
+            return array();
+        }
+
+        $images    = array();
+        $image_ids = array();
+
+        $featured_id = $product->get_image_id();
+        if ( $featured_id ) {
+            $image_ids[] = $featured_id;
+        }
+
+        $gallery_ids = $product->get_gallery_image_ids();
+        if ( ! empty( $gallery_ids ) ) {
+            $image_ids = array_merge( $image_ids, $gallery_ids );
+        }
+
+        $image_ids = array_unique( array_filter( array_map( 'absint', $image_ids ) ) );
+
+        foreach ( $image_ids as $attachment_id ) {
+            $src = wp_get_attachment_image_url( $attachment_id, 'full' );
+            if ( ! $src ) {
+                continue;
+            }
+
+            $images[] = array(
+                'id'  => $attachment_id,
+                'src' => esc_url_raw( $src ),
+                'alt' => get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ),
+            );
+        }
+
+        $categories = array();
+        $terms      = wp_get_post_terms( $product->get_id(), 'product_cat', array( 'fields' => 'all' ) );
+        if ( ! is_wp_error( $terms ) ) {
+            foreach ( $terms as $term ) {
+                $categories[] = array(
+                    'id'   => $term->term_id,
+                    'name' => $term->name,
+                    'slug' => $term->slug,
+                );
+            }
+        }
+
+        $attributes = array();
+        foreach ( $product->get_attributes() as $attribute ) {
+            if ( is_object( $attribute ) && method_exists( $attribute, 'get_name' ) ) {
+                $attribute_name = $attribute->get_name();
+                $attribute_data = array(
+                    'name'    => wc_attribute_label( $attribute_name ),
+                    'slug'    => $attribute_name,
+                    'options' => $attribute->get_options(),
+                );
+            } else {
+                $attribute_data = array(
+                    'name'    => '',
+                    'slug'    => '',
+                    'options' => array(),
+                );
+            }
+
+            $attributes[] = $attribute_data;
+        }
+
+        $data = array(
+            'id'                => $product->get_id(),
+            'type'              => $product->get_type(),
+            'sku'               => $product->get_sku(),
+            'name'              => $product->get_name(),
+            'slug'              => $product->get_slug(),
+            'permalink'         => get_permalink( $product->get_id() ),
+            'description'       => wp_kses_post( $product->get_description() ),
+            'short_description' => wp_kses_post( $product->get_short_description() ),
+            'price'             => $product->get_price(),
+            'regular_price'     => $product->get_regular_price(),
+            'sale_price'        => $product->get_sale_price(),
+            'currency'          => get_woocommerce_currency(),
+            'manage_stock'      => $product->get_manage_stock(),
+            'stock_status'      => $product->get_stock_status(),
+            'stock_quantity'    => $product->get_stock_quantity(),
+            'images'            => $images,
+            'categories'        => $categories,
+            'attributes'        => $attributes,
+            'updated_at'        => get_post_modified_time( DATE_ATOM, true, $product->get_id() ),
+        );
+
+        if ( $product->is_type( 'variable' ) ) {
+            $variations = array();
+            foreach ( $product->get_children() as $child_id ) {
+                $variation = wc_get_product( $child_id );
+                if ( ! $variation || ! is_a( $variation, 'WC_Product' ) ) {
+                    continue;
+                }
+
+                $variations[] = array(
+                    'id'             => $variation->get_id(),
+                    'sku'            => $variation->get_sku(),
+                    'price'          => $variation->get_price(),
+                    'regular_price'  => $variation->get_regular_price(),
+                    'sale_price'     => $variation->get_sale_price(),
+                    'stock_status'   => $variation->get_stock_status(),
+                    'stock_quantity' => $variation->get_stock_quantity(),
+                    'attributes'     => $variation->get_attributes(),
+                );
+            }
+
+            $data['variations'] = $variations;
+        }
+
+        return $data;
+    }
+
+    /**
+     * Retrieve a single product representation.
+     *
+     * @param WP_REST_Request $request REST request.
+     *
+     * @return WP_REST_Response|WP_Error
+     */
+    public function rest_get_single_product( $request ) {
+        if ( ! class_exists( 'WooCommerce' ) ) {
+            return new WP_Error( 'lotuslisans_woocommerce_missing', __( 'WooCommerce etkin değil.', 'lotuslisans-reseller' ), array( 'status' => 503 ) );
+        }
+
+        $product_id = absint( $request->get_param( 'id' ) );
+        $product    = wc_get_product( $product_id );
+
+        if ( ! $product || 'publish' !== $product->get_status() ) {
+            return new WP_Error( 'lotuslisans_product_not_found', __( 'Ürün bulunamadı.', 'lotuslisans-reseller' ), array( 'status' => 404 ) );
+        }
+
+        return rest_ensure_response(
+            array(
+                'data' => $this->format_product_for_api( $product ),
+            )
+        );
+    }
+
+    /**
+     * Create an order on behalf of the API consumer.
+     *
+     * @param WP_REST_Request $request REST request.
+     *
+     * @return WP_REST_Response|WP_Error
+     */
+    public function rest_create_order( $request ) {
+        if ( ! class_exists( 'WooCommerce' ) ) {
+            return new WP_Error( 'lotuslisans_woocommerce_missing', __( 'WooCommerce etkin değil.', 'lotuslisans-reseller' ), array( 'status' => 503 ) );
+        }
+
+        $product_id = absint( $request->get_param( 'product_id' ) );
+        $quantity   = max( 1, absint( $request->get_param( 'quantity' ) ) );
+
+        $product = wc_get_product( $product_id );
+
+        if ( ! $product || 'publish' !== $product->get_status() ) {
+            return new WP_Error( 'lotuslisans_product_not_found', __( 'Ürün bulunamadı.', 'lotuslisans-reseller' ), array( 'status' => 404 ) );
+        }
+
+        $order = wc_create_order();
+
+        if ( is_wp_error( $order ) ) {
+            return $order;
+        }
+
+        if ( method_exists( $order, 'set_created_via' ) ) {
+            $order->set_created_via( 'lotuslisans-reseller-api' );
+        }
+
+        try {
+            $order->add_product( $product, $quantity );
+            $order->calculate_totals();
+        } catch ( Exception $exception ) {
+            return new WP_Error( 'lotuslisans_order_error', $exception->getMessage(), array( 'status' => 400 ) );
+        }
+
+        $customer_id = $request->get_attribute( 'lotuslisans_user_id' );
+        if ( $customer_id && method_exists( $order, 'set_customer_id' ) ) {
+            $order->set_customer_id( (int) $customer_id );
+        }
+
+        $customer_email = $request->get_param( 'customer_email' );
+        if ( ! empty( $customer_email ) && method_exists( $order, 'set_billing_email' ) ) {
+            $order->set_billing_email( sanitize_email( $customer_email ) );
+        }
+
+        $customer_name = $request->get_param( 'customer_name' );
+        if ( ! empty( $customer_name ) ) {
+            $name_parts = explode( ' ', $customer_name, 2 );
+            $first_name = isset( $name_parts[0] ) ? sanitize_text_field( $name_parts[0] ) : '';
+            $last_name  = isset( $name_parts[1] ) ? sanitize_text_field( $name_parts[1] ) : '';
+
+            if ( method_exists( $order, 'set_billing_first_name' ) ) {
+                $order->set_billing_first_name( $first_name );
+            }
+
+            if ( method_exists( $order, 'set_billing_last_name' ) ) {
+                $order->set_billing_last_name( $last_name );
+            }
+        }
+
+        $note = $request->get_param( 'note' );
+        if ( ! empty( $note ) && method_exists( $order, 'add_order_note' ) ) {
+            $order->add_order_note( sanitize_textarea_field( $note ), false, false );
+        }
+
+        $order->update_meta_data( '_lotuslisans_reseller_api_consumer', $request->get_attribute( 'lotuslisans_user_id' ) );
+        $order->save();
+
+        return rest_ensure_response(
+            array(
+                'data' => array(
+                    'order_id' => $order->get_id(),
+                    'status'   => $order->get_status(),
+                    'total'    => $order->get_total(),
+                    'currency' => $order->get_currency(),
+                ),
+            )
+        );
+    }
+
+    /**
+     * Provide access to the admin handler.
+     *
+     * @return LotusLisans_Admin
+     */
+    public function admin() {
+        return $this->admin;
+    }
+
+    /**
+     * Provide access to the API client.
+     *
+     * @return LotusLisans_API_Client
+     */
+    public function api_client() {
+        return $this->api_client;
+    }
+}

--- a/lotuslisans-reseller/lotuslisans-reseller.php
+++ b/lotuslisans-reseller/lotuslisans-reseller.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Plugin Name: LotusLisans Reseller for WooCommerce
+ * Plugin URI: https://partner.lotuslisans.com.tr/
+ * Description: WooCommerce entegrasyonu ile LotusLisans ürünlerini yönetin.
+ * Version: 1.0.0
+ * Author: LotusLisans Entegrasyon
+ * License: GPLv2 or later
+ * Text Domain: lotuslisans-reseller
+ * Domain Path: /languages
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+if ( ! defined( 'LOTUSLISANS_RESELLER_FILE' ) ) {
+    define( 'LOTUSLISANS_RESELLER_FILE', __FILE__ );
+}
+
+define( 'LOTUSLISANS_RESELLER_PATH', plugin_dir_path( LOTUSLISANS_RESELLER_FILE ) );
+define( 'LOTUSLISANS_RESELLER_URL', plugin_dir_url( LOTUSLISANS_RESELLER_FILE ) );
+define( 'LOTUSLISANS_RESELLER_VERSION', '1.0.0' );
+
+require_once LOTUSLISANS_RESELLER_PATH . 'includes/class-lotuslisans-reseller-plugin.php';
+
+function lotuslisans_reseller() {
+    return LotusLisans_Reseller_Plugin::instance();
+}
+
+lotuslisans_reseller();

--- a/lotuslisans-reseller/templates/api-docs.php
+++ b/lotuslisans-reseller/templates/api-docs.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Reseller API documentation template.
+ *
+ * @package LotusLisansReseller
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+get_header();
+
+$api_base          = trailingslashit( rest_url( 'lotuslisans-reseller/v1' ) );
+$products_endpoint = $api_base . 'products';
+$orders_endpoint   = $api_base . 'orders';
+$plugin            = function_exists( 'lotuslisans_reseller' ) ? lotuslisans_reseller() : null;
+$docs_title        = __( 'Reseller API Dokümantasyonu', 'lotuslisans-reseller' );
+?>
+<div class="lotuslisans-api-docs" style="max-width: 960px; margin: 40px auto; padding: 0 20px;">
+    <h1><?php echo esc_html( $docs_title ); ?></h1>
+    <p><?php esc_html_e( 'Bu doküman, mağazamızdaki ürünleri kendi sitenize aktarıp satışa sunmanız için hazırlanan Reseller API hakkında ayrıntılı bilgi sağlar.', 'lotuslisans-reseller' ); ?></p>
+
+    <section>
+        <h2><?php esc_html_e( 'Kimlik Doğrulama', 'lotuslisans-reseller' ); ?></h2>
+        <p><?php esc_html_e( 'Tüm isteklerde hesabınıza özel API anahtarını kullanmanız gerekir. Anahtarınıza WooCommerce "Hesabım" sayfanızdaki Reseller API panelinden ulaşabilirsiniz.', 'lotuslisans-reseller' ); ?></p>
+        <ul>
+            <li><?php esc_html_e( 'Header: X-API-Key: YOUR_KEY', 'lotuslisans-reseller' ); ?></li>
+            <li><?php esc_html_e( 'Sorgu parametresi: ?api_key=YOUR_KEY', 'lotuslisans-reseller' ); ?></li>
+        </ul>
+        <p><?php esc_html_e( 'Geçersiz veya eksik anahtar kullanılırsa istek 401 Unauthorized hatası döndürür.', 'lotuslisans-reseller' ); ?></p>
+    </section>
+
+    <section>
+        <h2><?php esc_html_e( 'Temel URL', 'lotuslisans-reseller' ); ?></h2>
+        <pre><code><?php echo esc_html( $api_base ); ?></code></pre>
+    </section>
+
+    <section>
+        <h2><?php esc_html_e( 'Uç Noktalar', 'lotuslisans-reseller' ); ?></h2>
+        <table style="width:100%; border-collapse: collapse;">
+            <thead>
+                <tr>
+                    <th style="text-align:left; border-bottom:1px solid #ddd; padding:8px;"><?php esc_html_e( 'Yöntem', 'lotuslisans-reseller' ); ?></th>
+                    <th style="text-align:left; border-bottom:1px solid #ddd; padding:8px;"><?php esc_html_e( 'Uç Nokta', 'lotuslisans-reseller' ); ?></th>
+                    <th style="text-align:left; border-bottom:1px solid #ddd; padding:8px;"><?php esc_html_e( 'Açıklama', 'lotuslisans-reseller' ); ?></th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td style="padding:8px;">GET</td>
+                    <td style="padding:8px;"><code>/products</code></td>
+                    <td style="padding:8px;"><?php esc_html_e( 'Yayınlanmış ürünleri sayfalı şekilde listeler. WooCommerce ürünlerinizi senkronize etmek için kullanabilirsiniz.', 'lotuslisans-reseller' ); ?></td>
+                </tr>
+                <tr>
+                    <td style="padding:8px;">GET</td>
+                    <td style="padding:8px;"><code>/products/{id}</code></td>
+                    <td style="padding:8px;"><?php esc_html_e( 'Tek bir ürünün tüm detaylarını döndürür.', 'lotuslisans-reseller' ); ?></td>
+                </tr>
+                <tr>
+                    <td style="padding:8px;">POST</td>
+                    <td style="padding:8px;"><code>/orders</code></td>
+                    <td style="padding:8px;"><?php esc_html_e( 'Belirtilen ürünü sepetinize ekleyerek mağazamızda yeni bir sipariş oluşturur. Otomatik teslimat iş akışı kurmak için kullanabilirsiniz.', 'lotuslisans-reseller' ); ?></td>
+                </tr>
+            </tbody>
+        </table>
+    </section>
+
+    <section>
+        <h2><?php esc_html_e( 'Ürün Listesi Örneği', 'lotuslisans-reseller' ); ?></h2>
+        <pre><code>GET <?php echo esc_html( $products_endpoint ); ?>?per_page=10&amp;page=1&amp;search=office</code></pre>
+        <pre><code>{
+  "data": [
+    {
+      "id": 120,
+      "name": "Office 2021 Pro Plus",
+      "price": "89.90",
+      "currency": "TRY",
+      "stock_status": "instock",
+      "updated_at": "2024-03-12T12:45:00+00:00"
+    }
+  ],
+  "meta": {
+    "page": 1,
+    "per_page": 10,
+    "total": 42,
+    "total_pages": 5,
+    "currency": "TRY"
+  }
+}</code></pre>
+        <p><?php esc_html_e( 'API, WooCommerce ürün verilerini döndürür; bu verilerle sitenizde otomatik ürün oluşturabilir, fiyat ve stok güncellemelerini düzenli olarak çekebilirsiniz.', 'lotuslisans-reseller' ); ?></p>
+    </section>
+
+    <section>
+        <h2><?php esc_html_e( 'Sipariş Oluşturma Örneği', 'lotuslisans-reseller' ); ?></h2>
+        <pre><code>POST <?php echo esc_html( $orders_endpoint ); ?>
+Header: X-API-Key: YOUR_KEY
+Body:
+{
+  "product_id": 120,
+  "quantity": 1,
+  "customer_email": "musteri@example.com",
+  "customer_name": "Müşteri Adı",
+  "note": "Sipariş notu"
+}</code></pre>
+        <pre><code>{
+  "data": {
+    "order_id": 4891,
+    "status": "processing",
+    "total": "89.90",
+    "currency": "TRY"
+  }
+}</code></pre>
+        <p><?php esc_html_e( 'Siparişler varsayılan olarak işleme alınır ve mağaza panelinizde görüntülenir. Webhook veya e-posta bildirimleri ile siparişleri takip edebilirsiniz.', 'lotuslisans-reseller' ); ?></p>
+    </section>
+
+    <section>
+        <h2><?php esc_html_e( 'Filtreleme ve Güncelleme Stratejileri', 'lotuslisans-reseller' ); ?></h2>
+        <ul>
+            <li><?php esc_html_e( 'updated_after parametresi ile yalnızca belirli tarihten sonra güncellenen ürünleri çekebilirsiniz.', 'lotuslisans-reseller' ); ?></li>
+            <li><?php esc_html_e( 'per_page değeri en fazla 100 olabilir. Daha yüksek hacimli senkronizasyonlarda sayfalama kullanınız.', 'lotuslisans-reseller' ); ?></li>
+            <li><?php esc_html_e( 'stock_status parametresi ile instock, onbackorder gibi stok durumlarına göre filtreleme yapabilirsiniz.', 'lotuslisans-reseller' ); ?></li>
+        </ul>
+    </section>
+
+    <section>
+        <h2><?php esc_html_e( 'WordPress/WooCommerce İçin Örnek Kod', 'lotuslisans-reseller' ); ?></h2>
+        <pre><code>add_action( 'init', function() {
+    $response = wp_remote_get( '<?php echo esc_url_raw( $products_endpoint ); ?>', array(
+        'headers' => array( 'X-API-Key' => 'YOUR_KEY' ),
+    ) );
+
+    if ( is_wp_error( $response ) ) {
+        return;
+    }
+
+    $body = json_decode( wp_remote_retrieve_body( $response ), true );
+    // $body['data'] içindeki ürünleri sitenize kaydedebilirsiniz.
+} );</code></pre>
+    </section>
+
+    <section>
+        <h2><?php esc_html_e( 'Özel Yazılımlar İçin Notlar', 'lotuslisans-reseller' ); ?></h2>
+        <ul>
+            <li><?php esc_html_e( 'Tüm yanıtlar JSON formatındadır. Başarılı istekler 200, kimlik doğrulaması olmayan istekler 401, bulunamayan kaynaklar 404 kodu döndürür.', 'lotuslisans-reseller' ); ?></li>
+            <li><?php esc_html_e( 'TLS (HTTPS) zorunludur. API anahtarınızı istemci tarafında saklarken şifreli depolama tercih ediniz.', 'lotuslisans-reseller' ); ?></li>
+            <li><?php esc_html_e( 'Siparişleriniz mağaza panelinizde işlenir ve faturalanır; stok güncellemelerini düzenli olarak ürün listesi üzerinden senkronize edebilirsiniz.', 'lotuslisans-reseller' ); ?></li>
+        </ul>
+    </section>
+
+    <section>
+        <h2><?php esc_html_e( 'Sık Sorulan Sorular', 'lotuslisans-reseller' ); ?></h2>
+        <dl>
+            <dt><?php esc_html_e( 'API anahtarımı nasıl yenilerim?', 'lotuslisans-reseller' ); ?></dt>
+            <dd><?php esc_html_e( 'WooCommerce hesabım sayfanızdaki "API Anahtarını Yenile" butonunu kullanabilirsiniz. Eski anahtar hemen geçersiz olur.', 'lotuslisans-reseller' ); ?></dd>
+            <dt><?php esc_html_e( 'Ürün fiyatları güncellendiğinde bildirim alabilir miyim?', 'lotuslisans-reseller' ); ?></dt>
+            <dd><?php esc_html_e( 'Planlı görevlerinizde updated_after filtresini kullanarak yeni fiyatları çekebilir veya mağaza panelinizdeki bildirimleri takip edebilirsiniz.', 'lotuslisans-reseller' ); ?></dd>
+            <dt><?php esc_html_e( 'Sipariş oluştururken müşteri bilgisi zorunlu mu?', 'lotuslisans-reseller' ); ?></dt>
+            <dd><?php esc_html_e( 'Hayır, ancak e-posta ve isim iletirseniz fatura ve teslimat iletişimi daha sağlıklı ilerler.', 'lotuslisans-reseller' ); ?></dd>
+        </dl>
+    </section>
+
+    <section>
+        <h2><?php esc_html_e( 'Destek', 'lotuslisans-reseller' ); ?></h2>
+        <p><?php esc_html_e( 'API ile ilgili talepleriniz için mağaza panelinizdeki destek kanallarından bize ulaşabilirsiniz.', 'lotuslisans-reseller' ); ?></p>
+        <?php if ( $plugin ) : ?>
+            <p><a class="button" href="<?php echo esc_url( admin_url( 'admin.php?page=lotuslisans-reseller' ) ); ?>"><?php esc_html_e( 'Yönetim Paneline Dön', 'lotuslisans-reseller' ); ?></a></p>
+        <?php endif; ?>
+    </section>
+</div>
+<?php
+get_footer();


### PR DESCRIPTION
## Summary
- add a helper to resolve the stored license option name with a literal fallback
- update activation and enforcement routines to use the helper to avoid constant lookup fatals on some hosts

## Testing
- find lotuslisans-reseller -name '*.php' -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_b_68e552ccccd4832181cb6b1c6557af1b