### PR TITLE
Add provider integrations and dashboard enhancements

### DIFF
--- a/lotuslisans-reseller/assets/css/admin.css
+++ b/lotuslisans-reseller/assets/css/admin.css
@@ -15,3 +15,88 @@
     list-style: disc;
     margin-left: 20px;
 }
+
+.lotuslisans-dashboard-metrics {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 20px;
+    margin: 20px 0;
+}
+
+.lotuslisans-dashboard-card {
+    background: #fff;
+    border: 1px solid #dcdcde;
+    border-radius: 8px;
+    padding: 16px;
+    flex: 1 1 220px;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
+}
+
+.lotuslisans-dashboard-card h3 {
+    margin-top: 0;
+}
+
+.lotuslisans-dashboard-value {
+    font-size: 28px;
+    font-weight: 600;
+    margin: 4px 0;
+}
+
+.lotuslisans-provider-grid {
+    display: grid;
+    gap: 20px;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    margin-top: 30px;
+}
+
+.lotuslisans-provider-card {
+    background: #fff;
+    border: 1px solid #dcdcde;
+    border-radius: 8px;
+    padding: 20px;
+    box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
+}
+
+.lotuslisans-provider-card h2 {
+    margin-top: 0;
+}
+
+.lotuslisans-provider-status {
+    display: flex;
+    align-items: center;
+    font-weight: 600;
+    gap: 8px;
+}
+
+.lotuslisans-status-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    display: inline-block;
+}
+
+.lotuslisans-status-dot.status-connected {
+    background-color: #1d9d5f;
+}
+
+.lotuslisans-status-dot.status-pending {
+    background-color: #d63638;
+}
+
+.lotuslisans-provider-form {
+    margin-bottom: 30px;
+}
+
+.lotuslisans-test-wrapper {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    margin: 12px 0 24px;
+}
+
+.lotuslisans-provider-page pre {
+    background: #f6f7f7;
+    border-radius: 4px;
+    padding: 12px;
+    overflow: auto;
+}

--- a/lotuslisans-reseller/includes/providers/class-lotuslisans-abstract-provider-client.php
+++ b/lotuslisans-reseller/includes/providers/class-lotuslisans-abstract-provider-client.php
@@ -1,0 +1,179 @@
+<?php
+/**
+ * Base provider client for external integrations.
+ *
+ * @package LotusLisansReseller
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+abstract class LotusLisans_Abstract_Provider_Client {
+
+    /**
+     * Plugin bootstrap instance.
+     *
+     * @var LotusLisans_Reseller_Plugin
+     */
+    protected $plugin;
+
+    /**
+     * Constructor.
+     *
+     * @param LotusLisans_Reseller_Plugin $plugin Plugin instance.
+     */
+    public function __construct( LotusLisans_Reseller_Plugin $plugin ) {
+        $this->plugin = $plugin;
+    }
+
+    /**
+     * Retrieve provider slug handled by the client.
+     *
+     * @return string
+     */
+    abstract protected function get_provider_slug();
+
+    /**
+     * Execute a connectivity test against the provider API.
+     *
+     * @return array|string|WP_Error
+     */
+    abstract public function test_connection();
+
+    /**
+     * Retrieve provider options.
+     *
+     * @return array
+     */
+    protected function get_options() {
+        return $this->plugin->get_provider_options( $this->get_provider_slug() );
+    }
+
+    /**
+     * Helper for building provider URLs.
+     *
+     * @param string $base_url Provider base URL.
+     * @param string $endpoint Endpoint path.
+     *
+     * @return string
+     */
+    protected function build_url( $base_url, $endpoint ) {
+        $base_url = untrailingslashit( $base_url );
+        $endpoint = '/' . ltrim( $endpoint, '/' );
+
+        return $base_url . $endpoint;
+    }
+
+    /**
+     * Perform an HTTP request.
+     *
+     * @param string $method HTTP method.
+     * @param string $url    Target URL.
+     * @param array  $args   Optional request arguments.
+     *
+     * @return array|WP_Error
+     */
+    protected function request( $method, $url, array $args = array() ) {
+        $defaults = array(
+            'method'  => strtoupper( $method ),
+            'timeout' => 20,
+            'headers' => array(
+                'Accept' => 'application/json',
+            ),
+        );
+
+        $args = wp_parse_args( $args, $defaults );
+
+        if ( isset( $args['body'] ) && is_array( $args['body'] ) ) {
+            $args['body'] = wp_json_encode( $args['body'] );
+            if ( ! isset( $args['headers']['Content-Type'] ) ) {
+                $args['headers']['Content-Type'] = 'application/json';
+            }
+        }
+
+        $response = wp_remote_request( $url, $args );
+
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+
+        $status = wp_remote_retrieve_response_code( $response );
+
+        if ( $status >= 200 && $status < 300 ) {
+            return $response;
+        }
+
+        $body    = wp_remote_retrieve_body( $response );
+        $message = $this->extract_error_message( $body, $status );
+
+        return new WP_Error( 'lotuslisans_provider_http_error', $message, array( 'status' => $status ) );
+    }
+
+    /**
+     * Decode provider response.
+     *
+     * @param array $response HTTP response.
+     *
+     * @return array|string|WP_Error
+     */
+    protected function decode_response( $response ) {
+        $body = wp_remote_retrieve_body( $response );
+
+        if ( '' === trim( $body ) ) {
+            return array();
+        }
+
+        $decoded = json_decode( $body, true );
+
+        if ( null !== $decoded || JSON_ERROR_NONE === json_last_error() ) {
+            return $decoded;
+        }
+
+        if ( function_exists( 'simplexml_load_string' ) ) {
+            $xml = @simplexml_load_string( $body ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+            if ( false !== $xml ) {
+                return json_decode( wp_json_encode( $xml ), true );
+            }
+        }
+
+        return trim( $body );
+    }
+
+    /**
+     * Provide default error messages for failed responses.
+     *
+     * @param string $body   Raw response body.
+     * @param int    $status HTTP status code.
+     *
+     * @return string
+     */
+    protected function extract_error_message( $body, $status ) {
+        $decoded = json_decode( $body, true );
+
+        if ( is_array( $decoded ) ) {
+            if ( isset( $decoded['message'] ) && is_string( $decoded['message'] ) ) {
+                return $decoded['message'];
+            }
+
+            if ( isset( $decoded['error'] ) ) {
+                if ( is_string( $decoded['error'] ) ) {
+                    return $decoded['error'];
+                }
+
+                return wp_json_encode( $decoded['error'] );
+            }
+        }
+
+        $body = trim( wp_strip_all_tags( $body ) );
+        if ( '' !== $body ) {
+            return $body;
+        }
+
+        return sprintf(
+            /* translators: %s: HTTP status code */
+            __( 'Servis %s hatası döndürdü.', 'lotuslisans-reseller' ),
+            absint( $status )
+        );
+    }
+}

--- a/lotuslisans-reseller/includes/providers/class-lotuslisans-netgsm-client.php
+++ b/lotuslisans-reseller/includes/providers/class-lotuslisans-netgsm-client.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * Netgsm API client helper.
+ *
+ * @package LotusLisansReseller
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class LotusLisans_Netgsm_Client extends LotusLisans_Abstract_Provider_Client {
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function get_provider_slug() {
+        return LotusLisans_Reseller_Plugin::PROVIDER_NETGSM;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function test_connection() {
+        $options  = $this->get_options();
+        $usercode = isset( $options['usercode'] ) ? trim( $options['usercode'] ) : '';
+        $password = isset( $options['password'] ) ? trim( $options['password'] ) : '';
+        $base_url = isset( $options['base_url'] ) && ! empty( $options['base_url'] ) ? $options['base_url'] : 'https://api.netgsm.com.tr';
+
+        if ( '' === $usercode || '' === $password ) {
+            return new WP_Error( 'lotuslisans_netgsm_missing_credentials', __( 'Netgsm kullanıcı kodu ve parolası zorunludur.', 'lotuslisans-reseller' ) );
+        }
+
+        $endpoint = apply_filters( 'lotuslisans_reseller_netgsm_balance_endpoint', '/account/balance/json' );
+        $url      = $this->build_url( $base_url, $endpoint );
+        $url      = add_query_arg(
+            array(
+                'usercode' => $usercode,
+                'password' => $password,
+            ),
+            $url
+        );
+
+        $response = $this->request( 'GET', $url );
+
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+
+        $decoded = $this->decode_response( $response );
+
+        $message = __( 'Netgsm bağlantısı doğrulandı.', 'lotuslisans-reseller' );
+        $data    = array();
+
+        if ( is_array( $decoded ) ) {
+            $data = $decoded;
+
+            if ( isset( $decoded['balance'] ) ) {
+                $message = sprintf(
+                    /* translators: %s: balance amount */
+                    __( 'Netgsm bakiyesi: %s', 'lotuslisans-reseller' ),
+                    $decoded['balance']
+                );
+            } elseif ( isset( $decoded['balanceTL'] ) ) {
+                $message = sprintf(
+                    /* translators: %s: balance amount */
+                    __( 'Netgsm bakiyesi: %s', 'lotuslisans-reseller' ),
+                    $decoded['balanceTL']
+                );
+            }
+        } elseif ( is_string( $decoded ) && '' !== $decoded ) {
+            $message = sprintf(
+                /* translators: %s: provider response */
+                __( 'Netgsm yanıtı: %s', 'lotuslisans-reseller' ),
+                $decoded
+            );
+            $data = array( 'response' => $decoded );
+        }
+
+        return array(
+            'message' => $message,
+            'data'    => $data,
+        );
+    }
+}

--- a/lotuslisans-reseller/includes/providers/class-lotuslisans-pinabi-client.php
+++ b/lotuslisans-reseller/includes/providers/class-lotuslisans-pinabi-client.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Pinabi API client helper.
+ *
+ * @package LotusLisansReseller
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class LotusLisans_Pinabi_Client extends LotusLisans_Abstract_Provider_Client {
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function get_provider_slug() {
+        return LotusLisans_Reseller_Plugin::PROVIDER_PINABI;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function test_connection() {
+        $options     = $this->get_options();
+        $base_url    = isset( $options['base_url'] ) && ! empty( $options['base_url'] ) ? $options['base_url'] : 'https://panel.pinabi.com/api';
+        $username    = isset( $options['username'] ) ? trim( $options['username'] ) : '';
+        $password    = isset( $options['password'] ) ? trim( $options['password'] ) : '';
+        $api_key     = isset( $options['api_key'] ) ? trim( $options['api_key'] ) : '';
+        $merchant_id = isset( $options['merchant_id'] ) ? trim( $options['merchant_id'] ) : '';
+
+        if ( '' === $username || '' === $password || '' === $api_key ) {
+            return new WP_Error( 'lotuslisans_pinabi_missing_credentials', __( 'Pinabi kullanıcı adı, parola ve API anahtarı alanları zorunludur.', 'lotuslisans-reseller' ) );
+        }
+
+        $endpoint = apply_filters( 'lotuslisans_reseller_pinabi_balance_endpoint', '/balance' );
+        $url      = $this->build_url( $base_url, $endpoint );
+
+        $body = array(
+            'username' => $username,
+            'password' => $password,
+            'api_key'  => $api_key,
+        );
+
+        if ( '' !== $merchant_id ) {
+            $body['merchant_id'] = $merchant_id;
+        }
+
+        $response = $this->request(
+            'POST',
+            $url,
+            array(
+                'body' => $body,
+            )
+        );
+
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+
+        $decoded = $this->decode_response( $response );
+        $message = __( 'Pinabi bağlantısı doğrulandı.', 'lotuslisans-reseller' );
+        $data    = array();
+
+        if ( is_array( $decoded ) ) {
+            $data = $decoded;
+
+            if ( isset( $decoded['balance'] ) ) {
+                $message = sprintf(
+                    /* translators: %s: balance amount */
+                    __( 'Pinabi bakiyesi: %s', 'lotuslisans-reseller' ),
+                    $decoded['balance']
+                );
+            } elseif ( isset( $decoded['message'] ) && is_string( $decoded['message'] ) ) {
+                $message = $decoded['message'];
+            }
+        } elseif ( is_string( $decoded ) && '' !== $decoded ) {
+            $message = sprintf(
+                /* translators: %s: provider response */
+                __( 'Pinabi yanıtı: %s', 'lotuslisans-reseller' ),
+                $decoded
+            );
+            $data = array( 'response' => $decoded );
+        }
+
+        return array(
+            'message' => $message,
+            'data'    => $data,
+        );
+    }
+}

--- a/lotuslisans-reseller/includes/providers/class-lotuslisans-turkpin-client.php
+++ b/lotuslisans-reseller/includes/providers/class-lotuslisans-turkpin-client.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Türkpin API client helper.
+ *
+ * @package LotusLisansReseller
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class LotusLisans_Turkpin_Client extends LotusLisans_Abstract_Provider_Client {
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function get_provider_slug() {
+        return LotusLisans_Reseller_Plugin::PROVIDER_TURKPIN;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function test_connection() {
+        $options     = $this->get_options();
+        $base_url    = isset( $options['base_url'] ) && ! empty( $options['base_url'] ) ? $options['base_url'] : 'https://panel.turkpin.net/api/v1';
+        $dealer_code = isset( $options['dealer_code'] ) ? trim( $options['dealer_code'] ) : '';
+        $api_key     = isset( $options['api_key'] ) ? trim( $options['api_key'] ) : '';
+        $secret_key  = isset( $options['secret_key'] ) ? trim( $options['secret_key'] ) : '';
+
+        if ( '' === $dealer_code || '' === $api_key || '' === $secret_key ) {
+            return new WP_Error( 'lotuslisans_turkpin_missing_credentials', __( 'Türkpin dealer kodu, API anahtarı ve gizli anahtar alanları zorunludur.', 'lotuslisans-reseller' ) );
+        }
+
+        $endpoint = apply_filters( 'lotuslisans_reseller_turkpin_balance_endpoint', '/balance' );
+        $url      = $this->build_url( $base_url, $endpoint );
+
+        $response = $this->request(
+            'POST',
+            $url,
+            array(
+                'body' => array(
+                    'dealer_code' => $dealer_code,
+                    'api_key'     => $api_key,
+                    'secret_key'  => $secret_key,
+                ),
+            )
+        );
+
+        if ( is_wp_error( $response ) ) {
+            return $response;
+        }
+
+        $decoded = $this->decode_response( $response );
+        $message = __( 'Türkpin bağlantısı doğrulandı.', 'lotuslisans-reseller' );
+        $data    = array();
+
+        if ( is_array( $decoded ) ) {
+            $data = $decoded;
+
+            if ( isset( $decoded['balance'] ) ) {
+                $message = sprintf(
+                    /* translators: %s: balance amount */
+                    __( 'Türkpin bakiyesi: %s', 'lotuslisans-reseller' ),
+                    $decoded['balance']
+                );
+            } elseif ( isset( $decoded['status'] ) && 'success' !== strtolower( (string) $decoded['status'] ) ) {
+                $message = sprintf(
+                    /* translators: %s: provider status */
+                    __( 'Türkpin yanıtı: %s', 'lotuslisans-reseller' ),
+                    $decoded['status']
+                );
+            }
+        } elseif ( is_string( $decoded ) && '' !== $decoded ) {
+            $message = sprintf(
+                /* translators: %s: provider response */
+                __( 'Türkpin yanıtı: %s', 'lotuslisans-reseller' ),
+                $decoded
+            );
+            $data = array( 'response' => $decoded );
+        }
+
+        return array(
+            'message' => $message,
+            'data'    => $data,
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- reorganize the reseller admin menu with a control panel and dedicated Lotus, Netgsm, Türkpin, and Pinabi pages
- extend plugin settings handling to store provider credentials and instantiate dedicated client classes for API connectivity tests
- refresh admin assets with reusable AJAX testing logic and dashboard styling for the new integration pages

## Testing
- php -l lotuslisans-reseller/includes/class-lotuslisans-reseller-plugin.php
- php -l lotuslisans-reseller/includes/class-lotuslisans-admin.php
- php -l lotuslisans-reseller/includes/providers/class-lotuslisans-abstract-provider-client.php
- php -l lotuslisans-reseller/includes/providers/class-lotuslisans-netgsm-client.php
- php -l lotuslisans-reseller/includes/providers/class-lotuslisans-turkpin-client.php
- php -l lotuslisans-reseller/includes/providers/class-lotuslisans-pinabi-client.php


------
https://chatgpt.com/codex/tasks/task_b_68e57a6eca9083218b1a837e9491a9ee